### PR TITLE
Add functions to retrieve execution path taken

### DIFF
--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -652,6 +652,16 @@ void ZEXPORT zlib_accel_set_config(ConfigTag tag, int value) {
   }
 }
 
+ExecutionPath zlib_accel_get_deflate_execution_path(z_streamp strm) {
+  DeflateSettings* deflate_settings = deflate_stream_settings.Get(strm);
+  return deflate_settings->path;
+}
+
+ExecutionPath zlib_accel_get_inflate_execution_path(z_streamp strm) {
+  InflateSettings* inflate_settings = inflate_stream_settings.Get(strm);
+  return inflate_settings->path;
+}
+
 enum class FileMode { NONE, READ, WRITE, APPEND };
 
 struct GzipFile {

--- a/zlib_accel.h
+++ b/zlib_accel.h
@@ -18,4 +18,9 @@ enum ConfigTag {
 
 enum ExecutionPath { UNDEFINED, ZLIB, QAT, IAA };
 
-void ZEXPORT zlib_accel_set_config(ConfigTag tag, int value);
+// Non-zlib APIs (for testing or non-transparent applications)
+ZEXTERN void ZEXPORT zlib_accel_set_config(ConfigTag tag, int value);
+ZEXTERN ExecutionPath ZEXPORT
+zlib_accel_get_deflate_execution_path(z_streamp strm);
+ZEXTERN ExecutionPath ZEXPORT
+zlib_accel_get_inflate_execution_path(z_streamp strm);


### PR DESCRIPTION
The functions allow tests to verify that the expected execution path was taken.

Function ZlibUncompressExpectError is split into two functions (following the same pattern used for the corresponding Compress functions)
- ZlibUncompressExpectFallback: determines whether fallback to zlib is expected given the settings
- ZlibUncompressExpectError: if fallback is expected, but configuration disables it, an error is expected.
