### PR TITLE
removed zlib conditional compilation

### DIFF
--- a/common.cmake
+++ b/common.cmake
@@ -5,7 +5,6 @@ option(USE_IAA "Use IAA (requires QPL)" OFF)
 option(USE_QAT "Use QAT (requires QATzip)" OFF)
 option(DEBUG_LOG "for logging" ON)
 option(COVERAGE "for coverage" OFF)
-option(QAT_ZLIB "Support Zlib format in QATzip. Requires modified QATzip." OFF)
 
 if(USE_IAA)
   add_compile_definitions(USE_IAA)
@@ -17,10 +16,6 @@ endif()
 
 if(DEBUG_LOG)
   add_compile_definitions(DEBUG_LOG)
-endif()
-
-if(QAT_ZLIB)
-  add_compile_definitions(QAT_ZLIB)
 endif()
 
 if(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/qat.cpp
+++ b/qat.cpp
@@ -17,14 +17,12 @@ QzSession_T *QATJob::GetQATSession(int window_bits, bool gzip_ext) {
         Init(&qzSession_deflate_raw, format);
       }
       return qzSession_deflate_raw;
-#ifdef QAT_ZLIB
     case CompressedFormat::ZLIB:
       if (qzSession_zlib == nullptr) {
         Init(&qzSession_zlib,
              format);  // we do not have zlib format in public enum of qatzip
       }
       return qzSession_zlib;
-#endif
     case CompressedFormat::GZIP:
       if (gzip_ext) {
         if (qzSession_gzip_ext == nullptr) {
@@ -50,12 +48,10 @@ void QATJob::CloseQATSession(int window_bits, bool gzip_ext) {
       Close(qzSession_deflate_raw);
       qzSession_deflate_raw = nullptr;
       break;
-#ifdef QAT_ZLIB
     case CompressedFormat::ZLIB:
       Close(qzSession_zlib);
       qzSession_zlib = nullptr;
       break;
-#endif
     case CompressedFormat::GZIP:
       if (gzip_ext) {
         Close(qzSession_gzip_ext);
@@ -122,12 +118,10 @@ void QATJob::Init(QzSession_T **qzSession, CompressedFormat format,
     case CompressedFormat::DEFLATE_RAW:
       deflateExt.deflate_params.data_fmt = QZ_DEFLATE_RAW;
       break;
-#ifdef QAT_ZLIB
     case CompressedFormat::ZLIB:
       deflateExt.deflate_params.data_fmt = QZ_DEFLATE_RAW;
       deflateExt.zlib_format = 1;
       break;
-#endif
     case CompressedFormat::GZIP:
       if (gzip_ext) {
         deflateExt.deflate_params.data_fmt = QZ_DEFLATE_GZIP_EXT;
@@ -268,9 +262,7 @@ int UncompressQAT(uint8_t *input, uint32_t *input_length, uint8_t *output,
 
 bool SupportedOptionsQAT(int window_bits, uint32_t input_length) {
   if ((window_bits >= -15 && window_bits <= -8) ||
-#ifdef QAT_ZLIB
       (window_bits >= 8 && window_bits <= 15) ||
-#endif
       (window_bits >= 24 && window_bits <= 31)) {
     if (input_length < QZ_COMP_THRESHOLD_DEFAULT) {
       Log(LogLevel::LOG_INFO,

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -604,12 +604,8 @@ TEST_P(ZlibTest, CompressDecompress) {
 #ifdef USE_QAT
     if (test_param.execution_path_compress == QAT &&
         input_length > QAT_HW_BUFF_SZ &&
-#ifdef QAT_ZLIB
         GetCompressedFormat(window_bits_uncompress) !=
             CompressedFormat::DEFLATE_RAW) {
-#else
-        GetCompressedFormat(window_bits_uncompress) == CompressedFormat::GZIP) {
-#endif
       // For data compressed by qzCompress, data is
       // made of multiple streams of hardware buffer size.
       ASSERT_TRUE(uncompressed_length <= QAT_HW_BUFF_SZ);


### PR DESCRIPTION
Removed QAT_ZLIB conditional compilation flag.
while running the test suite 4 tests fail but when these tests are run individually they pass.

./zlib_accel_test --gtest_filter=CompressDecompress/ZlibTest.CompressDecompress/902
Note: Google Test filter = CompressDecompress/ZlibTest.CompressDecompress/902
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CompressDecompress/ZlibTest
[ RUN      ] CompressDecompress/ZlibTest.CompressDecompress/902
[       OK ] CompressDecompress/ZlibTest.CompressDecompress/902 (1598 ms)
[----------] 1 test from CompressDecompress/ZlibTest (1598 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1599 ms total)
[  PASSED  ] 1 test.
ubuntu@ip-10-0-17-56:~/zlib-accel-old/tests/build$ ./zlib_accel_test --gtest_filter=CompressDecompress/ZlibTest.CompressDecompress/1262
Note: Google Test filter = CompressDecompress/ZlibTest.CompressDecompress/1262
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CompressDecompress/ZlibTest
[ RUN      ] CompressDecompress/ZlibTest.CompressDecompress/1262
[       OK ] CompressDecompress/ZlibTest.CompressDecompress/1262 (1602 ms)
[----------] 1 test from CompressDecompress/ZlibTest (1602 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1602 ms total)
[  PASSED  ] 1 test.
ubuntu@ip-10-0-17-56:~/zlib-accel-old/tests/build$ ./zlib_accel_test --gtest_filter=CompressDecompress/ZlibTest.CompressDecompress/2342
Note: Google Test filter = CompressDecompress/ZlibTest.CompressDecompress/2342
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CompressDecompress/ZlibTest
[ RUN      ] CompressDecompress/ZlibTest.CompressDecompress/2342
[       OK ] CompressDecompress/ZlibTest.CompressDecompress/2342 (1596 ms)
[----------] 1 test from CompressDecompress/ZlibTest (1596 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1597 ms total)
[  PASSED  ] 1 test.
ubuntu@ip-10-0-17-56:~/zlib-accel-old/tests/build$ ./zlib_accel_test --gtest_filter=CompressDecompress/ZlibTest.CompressDecompress/2702
Note: Google Test filter = CompressDecompress/ZlibTest.CompressDecompress/2702
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from CompressDecompress/ZlibTest
[ RUN      ] CompressDecompress/ZlibTest.CompressDecompress/2702
[       OK ] CompressDecompress/ZlibTest.CompressDecompress/2702 (1599 ms)
[----------] 1 test from CompressDecompress/ZlibTest (1599 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (1599 ms total)
[  PASSED  ] 1 test.