### PR TITLE
Selectively disable clang -fsanitize=cfi-icall

### DIFF
--- a/.github/workflows/tests_clang.yml
+++ b/.github/workflows/tests_clang.yml
@@ -1,10 +1,10 @@
-name: zlib-accel clang build
+name: zlib-accel Build and Test (clang)
 on:
 - push
 - pull_request
 jobs:
-  build_zlib_accel:
-    name: Build zlib-accel
+  build_and_test_zlib_accel:
+    name: Build and test zlib-accel
     runs-on: ubuntu-latest
     steps:
     - name: Print system info
@@ -58,4 +58,10 @@ jobs:
         cd build
         cmake -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ ..
         make
+        
+    - name: Run unit tests
+      run: |
+        pwd
+        cd tests/build
+        make run
     

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project (zlib-accel
         DESCRIPTION "Zlib shim to accelerate deflate/inflate")
 
 include(common.cmake)
+link_libraries(dl)
 
 add_library(${PROJECT_NAME} SHARED config/config_reader.cpp config/config.cpp zlib_accel.cpp iaa.cpp qat.cpp utils.cpp sharded_map.h)
 

--- a/common.cmake
+++ b/common.cmake
@@ -46,6 +46,7 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+
 if(USE_IAA)
   if(NOT DEFINED QPL_PATH)
     find_package(Qpl REQUIRED)
@@ -71,4 +72,3 @@ if(USE_QAT)
 endif()
 
 link_libraries(z)
-link_libraries(dl)

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -28,7 +28,8 @@
 
 // Disable cfi-icall as it makes calls to orig* functions fail
 #if defined(__clang__)
-#pragma clang attribute push (__attribute__((no_sanitize("cfi-icall"))), apply_to=function)
+#pragma clang attribute push(__attribute__((no_sanitize("cfi-icall"))), \
+                             apply_to = function)
 #endif
 
 // Original zlib functions

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -26,6 +26,11 @@
 #include "qat.h"
 #endif
 
+// Disable cfi-icall as it makes calls to orig* functions fail
+#if defined(__clang__)
+#pragma clang attribute push (__attribute__((no_sanitize("cfi-icall"))), apply_to=function)
+#endif
+
 // Original zlib functions
 static int (*orig_deflateInit_)(z_streamp strm, int level, const char* version,
                                 int stream_size);
@@ -1286,3 +1291,7 @@ int ZEXPORT gzeof(gzFile file) {
   GzipFile* gz = gzip_files.Get(file);
   return gz->reached_eof;
 }
+
+#if defined(__clang__)
+#pragma clang attribute pop
+#endif


### PR DESCRIPTION
Pointers to zlib functions are obtained through dlsym. The -fsanitize=cfi-icall scheme prevents calls to these functions.
Also link dl only to the shared library, not tests.