### PR TITLE
Fix a couple of spelling mistakes

### DIFF
--- a/config/config_reader.cpp
+++ b/config/config_reader.cpp
@@ -57,7 +57,7 @@ bool ConfigReader::GetValue(std::string tag, std::string& value) {
 bool ConfigReader::ParseFile(string file_name) {
   ifstream input_file;
   input_file.open(file_name.c_str());
-  string delimeter = "=";
+  string delimiter = "=";
   int initPos = 0;
 
   if (input_file.fail()) {
@@ -76,7 +76,7 @@ bool ConfigReader::ParseFile(string file_name) {
 
     if (config_data.empty()) continue;
 
-    size_t length = config_data.find(delimeter);
+    size_t length = config_data.find(delimiter);
 
     string tag, value;
 

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -984,7 +984,7 @@ INSTANTIATE_TEST_SUITE_P(
         testing::Values(Z_SYNC_FLUSH), testing::Values(1),
         // Testing 32k instead of 16k blocks, to make IAA success/failure
         // predictable. With 16k divided into two 8k streams, sometimes IAA is
-        // able to decompress if no references happend to be farther than 4kB.
+        // able to decompress if no references happened to be farther than 4kB.
         testing::Values(1024, 32768, 262144),
         testing::Values(compressible_block, incompressible_block),
         testing::Values(false)));


### PR DESCRIPTION
Fix a variable name spelling mistake and a spelling mistake in a comment. No functional change.