### PR TITLE
Make block header logging consistent

### DIFF
--- a/logging.h
+++ b/logging.h
@@ -65,16 +65,12 @@ static inline void PrintDeflateBlockHeader(LogLevel level, uint8_t* data,
     return;
   }
 
-  FILE* stream = stdout;
-  if (log_file_stream != nullptr) {
-    stream = log_file_stream;
-  }
-
   CompressedFormat format = GetCompressedFormat(window_bits);
   uint32_t header_length = GetHeaderLength(format);
   if (len >= (header_length + 1)) {
-    fprintf(stream, "bfinal=%d, btype=%d\n", data[header_length] & 0b00000001,
-            (data[header_length] & 0b00000110) >> 1);
+    Log(level, "Deflate block header bfinal=%d, btype=%d\n",
+        data[header_length] & 0b00000001,
+        (data[header_length] & 0b00000110) >> 1);
   }
 }
 #else

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1090,6 +1090,8 @@ TEST_F(ConfigLoaderTest, LoadInvalidConfig) {
   EXPECT_EQ(GetConfig(USE_ZLIB_UNCOMPRESS), 0);
   EXPECT_EQ(GetConfig(LOG_LEVEL), 0);
   std::remove("/tmp/invalid_config");
+  // Restore config from official config file
+  LoadConfigFile(file_content);
 }
 
 TEST_F(ConfigLoaderTest, LoadValidConfig) {
@@ -1102,6 +1104,7 @@ TEST_F(ConfigLoaderTest, LoadValidConfig) {
   EXPECT_EQ(GetConfig(USE_ZLIB_COMPRESS), 1);
   EXPECT_EQ(GetConfig(USE_ZLIB_UNCOMPRESS), 1);
   EXPECT_EQ(GetConfig(LOG_LEVEL), 2);
+  LoadConfigFile(file_content);
 }
 
 TEST_F(ConfigLoaderTest, SymbolicLinkTest) {

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -121,7 +121,6 @@ static int init_zlib_accel(void) {
   if (!config::log_file.empty()) {
     CreateLogFile(config::log_file.c_str());
   }
-
 #endif
   return 0;
 }


### PR DESCRIPTION
Also small fix in tests. After config tests, restore configuration from file. Otherwise, logging during tests cannot be controlled from the config file.