### PR TITLE
IAA compressed size check

### DIFF
--- a/iaa.cpp
+++ b/iaa.cpp
@@ -55,7 +55,7 @@ uint32_t GetFormatFlag(int window_bits) {
 
 int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
                 uint32_t* output_length, qpl_path_t execution_path,
-                int window_bits, bool gzip_ext) {
+                int window_bits, uint32_t max_compressed_size, bool gzip_ext) {
   Log(LogLevel::LOG_INFO, "CompressIAA() Line %d input_length %d\n", __LINE__,
       *input_length);
 
@@ -115,6 +115,12 @@ int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
   if (status != QPL_STS_OK) {
     Log(LogLevel::LOG_ERROR, "CompressIAA() Line %d status %d\n", __LINE__,
         status);
+    return 1;
+  }
+  // In some cases, QPL compressed data size is larger than the upper bound
+  // provided by zlib deflateBound.
+  // TODO identify exact conditions and implement more permanent fix.
+  if (max_compressed_size > 0 && job->total_out > max_compressed_size) {
     return 1;
   }
 

--- a/iaa.h
+++ b/iaa.h
@@ -40,7 +40,8 @@ class IAAJob {
 
 int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
                 uint32_t* output_length, qpl_path_t execution_path,
-                int window_bits, bool gzip_ext = false);
+                int window_bits, uint32_t max_compressed_size = 0,
+                bool gzip_ext = false);
 
 int UncompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
                   uint32_t* output_length, qpl_path_t execution_path,

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -263,8 +263,12 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
     if (path_selected == IAA) {
 #ifdef USE_IAA
       in_call = true;
+      // Casting to uint32_t is safe, as IAA is not used for any blocks larger
+      // than 2MB
+      uint32_t max_compressed_size = (uint32_t)deflateBound(strm, input_len);
       ret = CompressIAA(strm->next_in, &input_len, strm->next_out, &output_len,
-                        qpl_path_hardware, deflate_settings->window_bits);
+                        qpl_path_hardware, deflate_settings->window_bits,
+                        max_compressed_size);
       deflate_settings->path = IAA;
       in_call = false;
       INCREMENT_STAT(DEFLATE_IAA_COUNT);
@@ -880,7 +884,7 @@ static int GzwriteAcceleratorCompress(GzipFile* gz, uint8_t* input,
 #ifdef USE_IAA
     in_call = true;
     ret = CompressIAA(input, input_length, output, output_length,
-                      qpl_path_hardware, 31, true);
+                      qpl_path_hardware, 31, 0, true);
     gz->path = IAA;
     in_call = false;
 #endif  // USE_IAA


### PR DESCRIPTION
In some cases, QPL compressed data size is larger than the upper bound provided by zlib deflateBound. A check is added to not use QPL's compressed output in those situations, until a more permanent solution is identified.

The issue was detected when running the following test in Cassandra with zlib-accel preloaded and IAA enabled for compression/decompression.
```
ant testsome -Dtest.name=org.apache.cassandra.io.compress.CompressorTest -Dtest.methods=testDeflateByteBuffers
```
The test fails due to the following exception
```
Caused by: java.nio.BufferOverflowException
        at java.base/java.nio.DirectByteBuffer.put(DirectByteBuffer.java:409)
        at org.apache.cassandra.io.compress.DeflateCompressor.compressBuffer(DeflateCompressor.java:146)
        at org.apache.cassandra.io.compress.DeflateCompressor.compress(DeflateCompressor.java:104)
        at org.apache.cassandra.io.compress.CompressorTest.testByteBuffers(CompressorTest.java:232)
```
Tested with Cassandra commit 4154632d16f20e753c40bbdb8c120c52a2da7629 (5/23/2025)