### PR TITLE
Intercept dictionary set functions and set execution path to zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,10 +235,11 @@ unset LD_PRELOAD
 ## Intercepted Zlib Functions
 
 deflate/inflate and related functions
-- deflateInit, deflateInit2, deflate, deflateEnd, deflateReset
-- inflateInit, inflateInit2, inflate, inflateEnd, inflateReset
+- deflateInit, deflateInit2, deflateSetDictionary, deflate, deflateEnd, deflateReset
+- inflateInit, inflateInit2, inflateSetDictionary, inflate, inflateEnd, inflateReset
 
-For deflate, offload is supported for Z_FINISH flush option. Support for additional options will be added in later releases. 
+For deflate, offload is supported for Z_FINISH flush option. Support for additional options will be added in later releases.   
+For deflateSetDictionary/inflateSetDictionary, zlib-accel simply sets the execution path to zlib, as dictionary compression is currently not supported for accelerators.
 
 utility functions
 - compress, uncompress


### PR DESCRIPTION
zlib-accel currently does not support hardware acceleration for dictionary compression. Intercept deflateSetDictionary and inflateSetDictionary and set the execution path to zlib. If these functions are not intercepted, subsequent calls to deflate/inflate may try to use accelerators.

The issue was highlighted by RocksDB tests when run with zlib-accel preloaded and IAA or QAT enabled. The following test was failing: DBTest2.PresetCompressionDict. Tested with RocksDB v10.2.1.