### PR TITLE
Fix potential double delete crash

### DIFF
--- a/iaa.h
+++ b/iaa.h
@@ -23,6 +23,10 @@ class IAAJob {
     }
   }
 
+  // Prevent copying a job
+  IAAJob(const IAAJob&) = delete;
+  IAAJob& operator=(const IAAJob&) = delete;
+
   qpl_job* GetJob(qpl_path_t execution_path) {
     if (jobs_[execution_path] == nullptr) {
       InitJob(execution_path);

--- a/qat.h
+++ b/qat.h
@@ -18,6 +18,11 @@ class QATJob {
  public:
   QATJob() {}
   ~QATJob() { Close(); }
+
+  // Prevent copying a job
+  QATJob(const QATJob&) = delete;
+  QATJob& operator=(const QATJob&) = delete;
+
   QzSession_T* GetQATSession(int window_bits, bool gzip_ext);
   void CloseQATSession(int window_bits, bool gzip_ext);
 


### PR DESCRIPTION
Prevents a double delete crash by making IAA and QAT jobs non-copyable. Currently, there is no such usage in the source code, and users are not expected to instantiate a IAA/QATJob themselves.

```c
  QATJob job_1;
  job_1.GetQATSession(10, false);
  
  QATJob job_2 = job_1;
  job_1.CloseQATSession(10, false); 
  
  job_2.GetQATSession(10, false);  // this will cause a crash
  ```