### PR TITLE
qat: map zlib-accel LogLevel to QATzip log level

### DIFF
--- a/qat.cpp
+++ b/qat.cpp
@@ -99,8 +99,24 @@ void QATJob::Init(QzSessionPtr &qzSession, CompressedFormat format,
     return;
   }
 
+  // Map log levels to QATzip log levels
+  LogLevel logLevel =
+      static_cast<LogLevel>(config::GetConfig(config::LOG_LEVEL));
+  QzLogLevel_T qzLogLevel = LOG_NONE;
+  switch (logLevel) {
+    default:
+      qzLogLevel = LOG_NONE;
+      break;
+    case LogLevel::LOG_INFO:
+      qzLogLevel = LOG_INFO;
+      break;
+    case LogLevel::LOG_ERROR:
+      qzLogLevel = LOG_DEBUG3;
+      break;
+  }
+  qzSetLogLevel(qzLogLevel);
+
   // Initialize QAT hardware
-  qzSetLogLevel(LOG_NONE);
   int status = qzInit(session.get(), 0);
   if (status != QZ_OK && status != QZ_DUPLICATE) {
     Log(LogLevel::LOG_ERROR, "qzInit() failure  Line ", __LINE__, "  session ",


### PR DESCRIPTION
Map zlib-accel log_level to QATzip log level in qat.cpp

Reads the configured `log_level` via `config::GetConfig(LOG_LEVEL)`, maps it to the corresponding [QzLogLevel_T](https://github.com/intel/QATzip/blob/master/include/qatzip.h#L944-L953) value, and applies it with qzSetLogLevel() so QATzip's logging verbosity follows the user's `/etc/zlib-accel.conf` setting.

```cpp
  LogLevel::LOG_NONE  -> LOG_NONE
  LogLevel::LOG_INFO  -> LOG_INFO
  LogLevel::LOG_ERROR -> LOG_DEBUG3
  ```