### PR TITLE
igzip: sync main (LOG_DEBUG) and rename dict stubs

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,10 @@ ignore_zlib_dictionary
 - If set to 0, zlib-accel honors inflateSetDictionary and deflateSetDictionary.
 
 log_level
-- Values: 0,1,2. Default 2
+- Values: 0,1,2,3. Default: 1
 - This option applies only if the shim is built with DEBUG_LOG=ON.
-- If 1, error and info log messages are shown. If 2, only error log messages are shown. If 0, no log messages are shown.
+- Matches QATzip's verbosity convention: 0 = silent, 1 = errors only, 2 = info and errors, 3 = debug, info, and errors (most verbose).
+- Migration note: the numeric meanings changed from earlier versions. Older configurations that used `log_level=2` for error-only output must now use `log_level=1`. Review existing `log_level` settings when upgrading.
 
 log_stats_samples
 - Values: 0-INT_MAX. Default 1000

--- a/config/config.cpp
+++ b/config/config.cpp
@@ -28,7 +28,7 @@ uint32_t configs[CONFIG_MAX] = {
     1,   /*qat_compression_level*/
     0,   /*qat_compression_allow_chunking*/
     0,   /*ignore_zlib_dictionary*/
-    2,   /*log_level*/
+    1,   /*log_level*/
     1000 /*log_stats_samples*/
 };
 
@@ -85,7 +85,7 @@ bool LoadConfigFile(std::string& file_content, const char* file_path) {
   trySetConfig(QAT_COMPRESSION_LEVEL, 9, 1);
   trySetConfig(QAT_COMPRESSION_ALLOW_CHUNKING, 1, 0);
   trySetConfig(IGNORE_ZLIB_DICTIONARY, 1, 0);
-  trySetConfig(LOG_LEVEL, 2, 0);
+  trySetConfig(LOG_LEVEL, 3, 0);
   trySetConfig(LOG_STATS_SAMPLES, UINT32_MAX, 0);
 
   config_reader.GetValue("log_file", log_file);

--- a/config/default_config
+++ b/config/default_config
@@ -11,5 +11,5 @@ qat_periodical_polling = 0
 qat_compression_level = 1
 qat_compression_allow_chunking = 0
 ignore_zlib_dictionary = 0
-log_level = 2
+log_level = 1
 log_file = /tmp/zlib-accel.log

--- a/igzip.cpp
+++ b/igzip.cpp
@@ -262,8 +262,8 @@ int EndCompressIGZIP(struct isal_zstream *isal_strm) {
   return Z_OK;
 }
 
-int deflateSetDictionary(z_streamp strm, unsigned char *dict_data,
-                         unsigned int dict_len) {
+int DeflateSetDictionaryIGZIP(z_streamp strm, unsigned char *dict_data,
+                              unsigned int dict_len) {
   if (!strm || !strm->state || !dict_data || dict_len == 0)
     return Z_STREAM_ERROR;
 
@@ -498,8 +498,8 @@ int EndUncompressIGZIP(struct inflate_state *isal_strm_inflate) {
   return Z_OK;
 }
 
-int inflateSetDictionary(z_streamp strm, unsigned char *dict_data,
-                         unsigned int dict_len) {
+int InflateSetDictionaryIGZIP(z_streamp strm, unsigned char *dict_data,
+                              unsigned int dict_len) {
   if (!strm || !strm->state || !dict_data || dict_len == 0)
     return Z_STREAM_ERROR;
 

--- a/igzip.h
+++ b/igzip.h
@@ -58,5 +58,9 @@ int UncompressIGZIP(struct inflate_state *isal_strm_inflate,
                     const unsigned long *total_out, bool *end_of_stream);
 int EndUncompressIGZIP(struct inflate_state *isal_strm_inflate);
 int ResetUncompressIGZIP(struct inflate_state *isal_strm_inflate);
+int DeflateSetDictionaryIGZIP(z_streamp strm, unsigned char *dict_data,
+                              unsigned int dict_len);
+int InflateSetDictionaryIGZIP(z_streamp strm, unsigned char *dict_data,
+                              unsigned int dict_len);
 // #define Z_DEFAULT_COMPRESSION 6
 #endif

--- a/logging.h
+++ b/logging.h
@@ -15,7 +15,14 @@
 
 using namespace config;
 
-enum class LogLevel { LOG_NONE = 0, LOG_INFO = 1, LOG_ERROR = 2 };
+// Log verbosity levels. 0 = silent; higher values = more verbose.
+// Matches QATzip's QzLogLevel_T convention.
+enum class LogLevel {
+  LOG_NONE = 0,
+  LOG_ERROR = 1,
+  LOG_INFO = 2,
+  LOG_DEBUG = 3
+};
 
 #if defined(DEBUG_LOG) || defined(ENABLE_STATISTICS)
 
@@ -56,7 +63,7 @@ inline void Log(LogLevel level, Args&&... args) {
     return;
   }
 
-  if (static_cast<uint32_t>(level) < current_level) {
+  if (static_cast<uint32_t>(level) > current_level) {
     return;
   }
 
@@ -68,6 +75,9 @@ inline void Log(LogLevel level, Args&&... args) {
       break;
     case LogLevel::LOG_INFO:
       stream << "Info: ";
+      break;
+    case LogLevel::LOG_DEBUG:
+      stream << "Debug: ";
       break;
     case LogLevel::LOG_NONE:
       return;
@@ -105,7 +115,7 @@ inline void PrintDeflateBlockHeader(LogLevel level, uint8_t* data, uint32_t len,
     return;
   }
 
-  if (static_cast<uint32_t>(level) < current_level) {
+  if (static_cast<uint32_t>(level) > current_level) {
     return;
   }
 

--- a/qat.cpp
+++ b/qat.cpp
@@ -99,8 +99,38 @@ void QATJob::Init(QzSessionPtr &qzSession, CompressedFormat format,
     return;
   }
 
+  // Map zlib-accel log level to QATzip log level.
+  // qzSetLogLevel is a QATzip global; call it once per process regardless
+  // of how many QAT sessions are created.
+  static std::once_flag qz_log_level_flag;
+  std::call_once(qz_log_level_flag, []() {
+    QzLogLevel_T qzLogLevel = LOG_NONE;
+#ifdef DEBUG_LOG
+    LogLevel logLevel =
+        static_cast<LogLevel>(config::GetConfig(config::LOG_LEVEL));
+    switch (logLevel) {
+      case LogLevel::LOG_NONE:
+        qzLogLevel = LOG_NONE;
+        break;
+      case LogLevel::LOG_ERROR:
+        qzLogLevel = LOG_ERROR;
+        break;
+      case LogLevel::LOG_INFO:
+        qzLogLevel = LOG_INFO;
+        break;
+      case LogLevel::LOG_DEBUG:
+        qzLogLevel = LOG_DEBUG3;
+        break;
+      default:
+        // Unreachable: all LogLevel values are handled above.
+        qzLogLevel = LOG_NONE;
+        break;
+    }
+#endif
+    qzSetLogLevel(qzLogLevel);
+  });
+
   // Initialize QAT hardware
-  qzSetLogLevel(LOG_NONE);
   int status = qzInit(session.get(), 0);
   if (status != QZ_OK && status != QZ_DUPLICATE) {
     Log(LogLevel::LOG_ERROR, "qzInit() failure  Line ", __LINE__, "  session ",

--- a/sharded_map.h
+++ b/sharded_map.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <functional>
+#include <mutex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>

--- a/tests/logging_test.cpp
+++ b/tests/logging_test.cpp
@@ -153,6 +153,46 @@ TEST_F(LoggingTest, LogErrorLevel) {
 }
 
 /**
+ * @test Verifies that DEBUG-level messages appear when LOG_LEVEL=DEBUG.
+ */
+TEST_F(LoggingTest, LogDebugLevel) {
+  CreateLogFile(test_log_file.c_str());
+  config::SetConfig(config::LOG_LEVEL,
+                    static_cast<uint32_t>(LogLevel::LOG_DEBUG));
+
+  Log(LogLevel::LOG_DEBUG, "debug message");
+  CloseLogFile();
+
+  std::ifstream f(test_log_file);
+  std::string c((std::istreambuf_iterator<char>(f)),
+                std::istreambuf_iterator<char>());
+
+  EXPECT_NE(c.find("Debug:"), std::string::npos);
+  EXPECT_NE(c.find("debug message"), std::string::npos);
+}
+
+/**
+ * @test Verifies that DEBUG-level messages are filtered out when
+ * LOG_LEVEL=INFO.
+ */
+TEST_F(LoggingTest, LogDebugFilteredByInfo) {
+  CreateLogFile(test_log_file.c_str());
+  config::SetConfig(config::LOG_LEVEL,
+                    static_cast<uint32_t>(LogLevel::LOG_INFO));
+
+  Log(LogLevel::LOG_DEBUG, "filtered debug");  // Should NOT appear
+  Log(LogLevel::LOG_INFO, "visible info");     // Should appear
+  CloseLogFile();
+
+  std::ifstream f(test_log_file);
+  std::string c((std::istreambuf_iterator<char>(f)),
+                std::istreambuf_iterator<char>());
+
+  EXPECT_EQ(c.find("filtered debug"), std::string::npos);
+  EXPECT_NE(c.find("visible info"), std::string::npos);
+}
+
+/**
  * @test Verifies that LOG_NONE prevents any message from being logged.
  */
 TEST_F(LoggingTest, LogNoneLevelReturnsEarly) {
@@ -191,7 +231,7 @@ TEST_F(LoggingTest, LogMultipleArguments) {
 
 /**
  * @test Validates that log-level filtering works correctly:
- *       - INFO log should be filtered out under LOG_ERROR
+ *       - DEBUG and INFO logs should be filtered out under LOG_ERROR
  *       - ERROR log should appear.
  */
 TEST_F(LoggingTest, LogLevelFiltering) {
@@ -199,15 +239,17 @@ TEST_F(LoggingTest, LogLevelFiltering) {
   config::SetConfig(config::LOG_LEVEL,
                     static_cast<uint32_t>(LogLevel::LOG_ERROR));
 
-  Log(LogLevel::LOG_INFO, "filtered");  // Should NOT appear
-  Log(LogLevel::LOG_ERROR, "visible");  // Should appear
+  Log(LogLevel::LOG_DEBUG, "filtered debug");  // Should NOT appear
+  Log(LogLevel::LOG_INFO, "filtered info");    // Should NOT appear
+  Log(LogLevel::LOG_ERROR, "visible");         // Should appear
   CloseLogFile();
 
   std::ifstream f(test_log_file);
   std::string c((std::istreambuf_iterator<char>(f)),
                 std::istreambuf_iterator<char>());
 
-  EXPECT_EQ(c.find("filtered"), std::string::npos);
+  EXPECT_EQ(c.find("filtered debug"), std::string::npos);
+  EXPECT_EQ(c.find("filtered info"), std::string::npos);
   EXPECT_NE(c.find("visible"), std::string::npos);
 }
 

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1274,7 +1274,7 @@ TEST_F(ConfigLoaderTest, LoadValidConfig) {
   EXPECT_EQ(GetConfig(USE_IAA_UNCOMPRESS), 0);
   EXPECT_EQ(GetConfig(USE_ZLIB_COMPRESS), 1);
   EXPECT_EQ(GetConfig(USE_ZLIB_UNCOMPRESS), 1);
-  EXPECT_EQ(GetConfig(LOG_LEVEL), 2);
+  EXPECT_EQ(GetConfig(LOG_LEVEL), 1);
   LoadConfigFile(file_content);
 }
 


### PR DESCRIPTION
Two housekeeping commits to prepare igzip for merge into main.

1. Merge branch 'main' into igzip
   Resolves conflict in config/config.cpp: keeps igzip's new
   igzip_fallback config key while picking up main's updated
   log_level defaults from PR #56 (LOG_DEBUG).

2. Rename deflateSetDictionary/inflateSetDictionary to IGZIP variants
   Renames the stub implementations in igzip.cpp to
   DeflateSetDictionaryIGZIP and InflateSetDictionaryIGZIP to
   eliminate the duplicate symbol conflict with the ZEXPORT versions
   in zlib_accel.cpp. Adds declarations to igzip.h. The stubs are
   preserved for future dictionary support pending performance
   validation.