### PR TITLE
Fix trivial undefined behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,9 @@ log_level
 
 log_stats_samples
 - Values: 0-INT_MAX. Default 1000
-- Append statistics to log every N samples (this option specifies N).
+- This option applies only if the shim is built with ENABLE_STATISTICS=ON.
+- Append statistics to log every N samples (this option specifies N). A sample is one deflate() or inflate() call.
+- If set to 0, statistics are not appended to the log.
 
 log_file
 - Values: path. Default: /tmp/zlib-accel.log

--- a/config/default_config
+++ b/config/default_config
@@ -13,4 +13,5 @@ qat_compression_allow_chunking = 0
 ignore_zlib_dictionary = 0
 map_shards = 64
 log_level = 1
+log_stats_samples = 1000
 log_file = /tmp/zlib-accel.log

--- a/iaa.cpp
+++ b/iaa.cpp
@@ -159,10 +159,10 @@ int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
       output[pos++] = 8;    // LEN
       output[pos++] = 0;
 
-      uint32_t tmp_val = *input_length;
-      std::memcpy(output + pos, &tmp_val, sizeof(uint32_t));
+      std::memcpy(output + pos, input_length, sizeof(uint32_t));
       pos += 4;
-      tmp_val = *output_length - header_length - GetTrailerLength(format);
+      uint32_t tmp_val =
+          *output_length - header_length - GetTrailerLength(format);
       std::memcpy(output + pos, &tmp_val, sizeof(uint32_t));
       pos += 4;
 

--- a/iaa.cpp
+++ b/iaa.cpp
@@ -6,6 +6,7 @@
 #include "iaa.h"
 
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <new>
 #include <thread>
@@ -90,8 +91,8 @@ int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
 
   uint32_t output_shift = 0;
   if (gzip_ext) {
-    job->next_out_ptr += GZIP_EXT_XHDR_SIZE;
     if (job->available_out >= GZIP_EXT_XHDR_SIZE) {
+      job->next_out_ptr += GZIP_EXT_XHDR_SIZE;
       job->available_out -= GZIP_EXT_XHDR_SIZE;
     } else {
       return 1;
@@ -158,10 +159,11 @@ int CompressIAA(uint8_t* input, uint32_t* input_length, uint8_t* output,
       output[pos++] = 8;    // LEN
       output[pos++] = 0;
 
-      *(uint32_t*)(output + pos) = *input_length;
+      uint32_t tmp_val = *input_length;
+      std::memcpy(output + pos, &tmp_val, sizeof(uint32_t));
       pos += 4;
-      *(uint32_t*)(output + pos) =
-          *output_length - header_length - GetTrailerLength(format);
+      tmp_val = *output_length - header_length - GetTrailerLength(format);
+      std::memcpy(output + pos, &tmp_val, sizeof(uint32_t));
       pos += 4;
 
       *output_length += GZIP_EXT_XHDR_SIZE;

--- a/logging.h
+++ b/logging.h
@@ -51,7 +51,7 @@ inline std::ostream& GetLogStream() {
 
 #ifdef DEBUG_LOG
 
-static std::mutex log_mutex;
+inline std::mutex log_mutex;
 template <typename... Args>
 inline void Log(LogLevel level, Args&&... args) {
   std::lock_guard<std::mutex> lock(log_mutex);

--- a/logging.h
+++ b/logging.h
@@ -47,11 +47,14 @@ inline std::ostream& GetLogStream() {
   return std::cout;
 }
 
+// Serializes writes to the stream returned by GetLogStream(). Shared by Log()
+// and LogStats(), which may write to the same stream from different threads.
+inline std::mutex log_mutex;
+
 #endif  // DEBUG_LOG || ENABLE_STATISTICS
 
 #ifdef DEBUG_LOG
 
-inline std::mutex log_mutex;
 template <typename... Args>
 inline void Log(LogLevel level, Args&&... args) {
   std::lock_guard<std::mutex> lock(log_mutex);
@@ -92,6 +95,7 @@ inline void Log(LogLevel level, Args&&... args) {
 
 template <typename... Args>
 inline void LogStats(Args&&... args) {
+  std::lock_guard<std::mutex> lock(log_mutex);
   std::ostream& stream = GetLogStream();
   stream << "Stats:\n";
   (..., (stream << args));

--- a/statistics.cpp
+++ b/statistics.cpp
@@ -25,6 +25,9 @@ const std::array<const char*, STATS_COUNT> stat_names{
 thread_local std::array<uint64_t, STATS_COUNT> stats{};
 
 void PrintStats() {
+  if (configs[LOG_STATS_SAMPLES] == 0) {
+    return;
+  }
   auto total_operations = stats[static_cast<size_t>(Statistic::DEFLATE_COUNT)] +
                           stats[static_cast<size_t>(Statistic::INFLATE_COUNT)];
   if (total_operations % configs[LOG_STATS_SAMPLES] != 0) {

--- a/utils.cpp
+++ b/utils.cpp
@@ -4,6 +4,7 @@
 #include "utils.h"
 
 #include <cstdint>
+#include <cstring>
 
 CompressedFormat GetCompressedFormat(int window_bits) {
   if (window_bits >= -15 && window_bits <= -8) {
@@ -86,7 +87,7 @@ bool DetectGzipExt(uint8_t* data, uint32_t len, uint32_t* src_size,
   }
 
   // Extract sizes from extended header
-  *src_size = *(reinterpret_cast<uint32_t*>(data + 16));
-  *dest_size = *(reinterpret_cast<uint32_t*>(data + 20));
+  std::memcpy(src_size, data + 16, sizeof(uint32_t));
+  std::memcpy(dest_size, data + 20, sizeof(uint32_t));
   return true;
 }


### PR DESCRIPTION
- Guard against division by zero in PrintStats() when log_stats_samples config is set to 0.

- Change 'static std::mutex log_mutex' to 'inline std::mutex log_mutex' in logging.h so all TUs share one mutex instance, preventing a data race on the shared log stream.

- Replace type-punned uint32_t pointer casts with memcpy in utils.cpp (DetectGzipExt) and iaa.cpp (CompressIAA) to avoid misaligned access and strict-aliasing violations.

- In CompressIAA, perform the available_out bounds check before advancing next_out_ptr, avoiding formation of an out-of-bounds pointer.