### PR TITLE
Fix security and concurrency undefined behavior

### DIFF
--- a/sharded_map.h
+++ b/sharded_map.h
@@ -39,21 +39,21 @@ class ShardedMap {
     pd_map_arr_ = std::make_unique<PaddedMapType[]>(num_shards_);
   }
 
-  auto Get(const Key& key) -> decltype(std::declval<Value>().get()) {
+  auto Get(const Key& key) -> std::shared_ptr<typename Value::element_type> {
     const auto shard = GetShard(key);
 #ifdef USE_TBB
     typename MapType::const_accessor acc;
     if (!pd_map_arr_[shard].map.find(acc, key)) {
       return nullptr;
     }
-    return acc->second.get();
+    return acc->second;
 #else
     std::shared_lock lock(pd_map_arr_[shard].mutex);
     auto it = pd_map_arr_[shard].map.find(key);
     if (it == pd_map_arr_[shard].map.end()) {
       return nullptr;
     }
-    return it->second.get();
+    return it->second;
 #endif
   }
 

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1323,55 +1323,55 @@ TEST_F(ConfigLoaderTest, MapShardsInvalidNonPowerOfTwo) {
 class ShardedMapTest : public ::testing::Test {};
 
 TEST_F(ShardedMapTest, BasicSetAndGet) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   std::string key = "test_key";
-  auto value = std::make_unique<int>(42);
+  auto value = std::make_shared<int>(42);
   int* raw_ptr = value.get();
 
   map.Set(key, std::move(value));
 
-  int* retrieved = map.Get(key);
+  auto retrieved = map.Get(key);
   ASSERT_NE(retrieved, nullptr);
   EXPECT_EQ(*retrieved, 42);
-  EXPECT_EQ(retrieved, raw_ptr);
+  EXPECT_EQ(retrieved.get(), raw_ptr);
 
   map.Unset(key);
 }
 
 TEST_F(ShardedMapTest, GetNonExistentKey) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
   EXPECT_EQ(map.Get("non_existent"), nullptr);
 }
 
 TEST_F(ShardedMapTest, SetOverwritesExistingKey) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   std::string key = "test_key";
-  auto value1 = std::make_unique<int>(100);
-  auto value2 = std::make_unique<int>(200);
+  auto value1 = std::make_shared<int>(100);
+  auto value2 = std::make_shared<int>(200);
   int* raw_ptr2 = value2.get();
 
   map.Set(key, std::move(value1));
   map.Set(key, std::move(value2));
 
-  int* retrieved = map.Get(key);
+  auto retrieved = map.Get(key);
   ASSERT_NE(retrieved, nullptr);
   EXPECT_EQ(*retrieved, 200);
-  EXPECT_EQ(retrieved, raw_ptr2);
+  EXPECT_EQ(retrieved.get(), raw_ptr2);
 
   map.Unset(key);
 }
 
 TEST_F(ShardedMapTest, UnsetRemovesKey) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   std::string key = "test_key";
-  auto value = std::make_unique<int>(42);
+  auto value = std::make_shared<int>(42);
 
   map.Set(key, std::move(value));
 
-  int* retrieved_before = map.Get(key);
+  auto retrieved_before = map.Get(key);
   ASSERT_NE(retrieved_before, nullptr);
 
   map.Unset(key);
@@ -1380,22 +1380,22 @@ TEST_F(ShardedMapTest, UnsetRemovesKey) {
 }
 
 TEST_F(ShardedMapTest, UnsetNonExistentKey) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
   EXPECT_NO_THROW(map.Unset("non_existent"));
 }
 
 TEST_F(ShardedMapTest, MultipleKeys) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   for (int i = 0; i < 10; i++) {
     std::string key = "key_" + std::to_string(i);
-    auto value = std::make_unique<int>(i * 10);
+    auto value = std::make_shared<int>(i * 10);
     map.Set(key, std::move(value));
   }
 
   for (int i = 0; i < 10; i++) {
     std::string key = "key_" + std::to_string(i);
-    int* value = map.Get(key);
+    auto value = map.Get(key);
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, i * 10);
   }
@@ -1409,18 +1409,18 @@ TEST_F(ShardedMapTest, MultipleKeys) {
 }
 
 TEST_F(ShardedMapTest, DifferentShards) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   std::vector<std::string> keys = {"key1",        "key2", "key3", "another_key",
                                    "yet_another", "test", "data", "value"};
 
   for (size_t i = 0; i < keys.size(); i++) {
-    auto value = std::make_unique<int>(i * 100);
+    auto value = std::make_shared<int>(i * 100);
     map.Set(keys[i], std::move(value));
   }
 
   for (size_t i = 0; i < keys.size(); i++) {
-    int* value = map.Get(keys[i]);
+    auto value = map.Get(keys[i]);
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, static_cast<int>(i * 100));
   }
@@ -1431,11 +1431,11 @@ TEST_F(ShardedMapTest, DifferentShards) {
 }
 
 TEST_F(ShardedMapTest, ConcurrentOperations) {
-  ShardedMap<std::string, std::unique_ptr<int>> map;
+  ShardedMap<std::string, std::shared_ptr<int>> map;
 
   for (int i = 0; i < 50; i++) {
     std::string key = "key_" + std::to_string(i);
-    auto value = std::make_unique<int>(i);
+    auto value = std::make_shared<int>(i);
     map.Set(key, std::move(value));
   }
 
@@ -1446,7 +1446,7 @@ TEST_F(ShardedMapTest, ConcurrentOperations) {
     threads.emplace_back([&map]() {
       for (int i = 0; i < 100; i++) {
         std::string key = "key_" + std::to_string(i % 50);
-        int* val = map.Get(key);
+        auto val = map.Get(key);
         ASSERT_NE(val, nullptr);
       }
     });
@@ -1457,7 +1457,7 @@ TEST_F(ShardedMapTest, ConcurrentOperations) {
     threads.emplace_back([&map, t]() {
       for (int i = 0; i < 20; i++) {
         std::string key = "new_key_" + std::to_string(t * 20 + i);
-        auto value = std::make_unique<int>(1000 + t * 20 + i);
+        auto value = std::make_shared<int>(1000 + t * 20 + i);
         map.Set(key, std::move(value));
       }
     });
@@ -1470,7 +1470,7 @@ TEST_F(ShardedMapTest, ConcurrentOperations) {
   // Original data should still be intact
   for (int i = 0; i < 50; i++) {
     std::string key = "key_" + std::to_string(i);
-    int* value = map.Get(key);
+    auto value = map.Get(key);
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, i);
   }
@@ -1479,7 +1479,7 @@ TEST_F(ShardedMapTest, ConcurrentOperations) {
   for (int t = 0; t < 5; t++) {
     for (int i = 0; i < 20; i++) {
       std::string key = "new_key_" + std::to_string(t * 20 + i);
-      int* value = map.Get(key);
+      auto value = map.Get(key);
       ASSERT_NE(value, nullptr);
       EXPECT_EQ(*value, 1000 + t * 20 + i);
     }
@@ -1498,15 +1498,15 @@ TEST_F(ShardedMapTest, ConcurrentOperations) {
 }
 
 TEST_F(ShardedMapTest, IntegerKeys) {
-  ShardedMap<int, std::unique_ptr<int>> map;
+  ShardedMap<int, std::shared_ptr<int>> map;
 
   for (int i = 0; i < 20; i++) {
-    auto value = std::make_unique<int>(i * 5);
+    auto value = std::make_shared<int>(i * 5);
     map.Set(i, std::move(value));
   }
 
   for (int i = 0; i < 20; i++) {
-    int* value = map.Get(i);
+    auto value = map.Get(i);
     ASSERT_NE(value, nullptr);
     EXPECT_EQ(*value, i * 5);
   }

--- a/utils.cpp
+++ b/utils.cpp
@@ -89,5 +89,11 @@ bool DetectGzipExt(uint8_t* data, uint32_t len, uint32_t* src_size,
   // Extract sizes from extended header
   std::memcpy(src_size, data + 16, sizeof(uint32_t));
   std::memcpy(dest_size, data + 20, sizeof(uint32_t));
+
+  // Validate that the claimed dest_size + header/footer fits within the input
+  // buffer. Reject if the addition would overflow or exceed the buffer length.
+  if (len < GZIP_EXT_HDRFTR_SIZE || *dest_size > len - GZIP_EXT_HDRFTR_SIZE) {
+    return false;
+  }
   return true;
 }

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -212,37 +212,37 @@ class DeflateStreamSettings {
  public:
   void Set(z_streamp strm, int level, int method, int window_bits,
            int mem_level, int strategy) {
-    auto settings = std::make_unique<DeflateSettings>(
+    auto settings = std::make_shared<DeflateSettings>(
         level, method, window_bits, mem_level, strategy);
     map.Set(strm, std::move(settings));
   }
 
   void Unset(z_streamp strm) { map.Unset(strm); }
 
-  DeflateSettings* Get(z_streamp strm) { return map.Get(strm); }
+  std::shared_ptr<DeflateSettings> Get(z_streamp strm) { return map.Get(strm); }
 
   void Init() { map.Init(); }
 
  private:
-  ShardedMap<z_streamp, std::unique_ptr<DeflateSettings>> map;
+  ShardedMap<z_streamp, std::shared_ptr<DeflateSettings>> map;
 };
 DeflateStreamSettings deflate_stream_settings;
 
 class InflateStreamSettings {
  public:
   void Set(z_streamp strm, int window_bits) {
-    auto settings = std::make_unique<InflateSettings>(window_bits);
+    auto settings = std::make_shared<InflateSettings>(window_bits);
     map.Set(strm, std::move(settings));
   }
 
   void Unset(z_streamp strm) { map.Unset(strm); }
 
-  InflateSettings* Get(z_streamp strm) { return map.Get(strm); }
+  std::shared_ptr<InflateSettings> Get(z_streamp strm) { return map.Get(strm); }
 
   void Init() { map.Init(); }
 
  private:
-  ShardedMap<z_streamp, std::unique_ptr<InflateSettings>> map;
+  ShardedMap<z_streamp, std::shared_ptr<InflateSettings>> map;
 };
 InflateStreamSettings inflate_stream_settings;
 
@@ -274,7 +274,7 @@ int ZEXPORT deflateSetDictionary(z_streamp strm, const Bytef* dictionary,
   if (!configs[IGNORE_ZLIB_DICTIONARY]) {
     Log(LogLevel::LOG_INFO, "deflateSetDictionary Line ", __LINE__, ", strm ",
         static_cast<void*>(strm), ", dictLength ", dictLength, "\n");
-    DeflateSettings* deflate_settings = deflate_stream_settings.Get(strm);
+    auto deflate_settings = deflate_stream_settings.Get(strm);
     deflate_settings->path = ZLIB;
     return orig_deflateSetDictionary(strm, dictionary, dictLength);
   }
@@ -285,7 +285,7 @@ int ZEXPORT deflateSetDictionary(z_streamp strm, const Bytef* dictionary,
 }
 
 int ZEXPORT deflate(z_streamp strm, int flush) {
-  DeflateSettings* deflate_settings = deflate_stream_settings.Get(strm);
+  auto deflate_settings = deflate_stream_settings.Get(strm);
   INCREMENT_STAT(DEFLATE_COUNT);
   PrintStats();
 
@@ -404,7 +404,7 @@ int ZEXPORT deflateEnd(z_streamp strm) {
 int ZEXPORT deflateReset(z_streamp strm) {
   Log(LogLevel::LOG_INFO, "deflateReset Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), "\n");
-  DeflateSettings* deflate_settings = deflate_stream_settings.Get(strm);
+  auto deflate_settings = deflate_stream_settings.Get(strm);
   if (deflate_settings != nullptr) {
     deflate_settings->path = UNDEFINED;
   }
@@ -434,7 +434,7 @@ int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef* dictionary,
   if (!configs[IGNORE_ZLIB_DICTIONARY]) {
     Log(LogLevel::LOG_INFO, "inflateSetDictionary Line ", __LINE__, ", strm ",
         static_cast<void*>(strm), "dictLength ", dictLength, "\n");
-    InflateSettings* inflate_settings = inflate_stream_settings.Get(strm);
+    auto inflate_settings = inflate_stream_settings.Get(strm);
     inflate_settings->path = ZLIB;
     return orig_inflateSetDictionary(strm, dictionary, dictLength);
   }
@@ -445,7 +445,7 @@ int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef* dictionary,
 }
 
 int ZEXPORT inflate(z_streamp strm, int flush) {
-  InflateSettings* inflate_settings = inflate_stream_settings.Get(strm);
+  auto inflate_settings = inflate_stream_settings.Get(strm);
   INCREMENT_STAT(INFLATE_COUNT);
   PrintStats();
 
@@ -583,7 +583,7 @@ int ZEXPORT inflateEnd(z_streamp strm) {
 int ZEXPORT inflateReset(z_streamp strm) {
   Log(LogLevel::LOG_INFO, "inflateReset Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), "\n");
-  InflateSettings* inflate_settings = inflate_stream_settings.Get(strm);
+  auto inflate_settings = inflate_stream_settings.Get(strm);
   if (inflate_settings != nullptr) {
     inflate_settings->path = UNDEFINED;
   }
@@ -741,12 +741,12 @@ int ZEXPORT uncompress(Bytef* dest, uLongf* destLen, const Bytef* source,
 }
 
 ExecutionPath GetDeflateExecutionPath(z_streamp strm) {
-  DeflateSettings* deflate_settings = deflate_stream_settings.Get(strm);
+  auto deflate_settings = deflate_stream_settings.Get(strm);
   return deflate_settings->path;
 }
 
 ExecutionPath GetInflateExecutionPath(z_streamp strm) {
-  InflateSettings* inflate_settings = inflate_stream_settings.Get(strm);
+  auto inflate_settings = inflate_stream_settings.Get(strm);
   return inflate_settings->path;
 }
 
@@ -839,18 +839,18 @@ struct GzipFile {
 class GzipFiles {
  public:
   void Set(gzFile file, int fd, FileMode file_mode) {
-    auto f = std::make_unique<GzipFile>(fd, file_mode);
+    auto f = std::make_shared<GzipFile>(fd, file_mode);
     map.Set(file, std::move(f));
   }
 
   void Unset(gzFile file) { map.Unset(file); }
 
-  GzipFile* Get(gzFile file) { return map.Get(file); }
+  std::shared_ptr<GzipFile> Get(gzFile file) { return map.Get(file); }
 
   void Init() { map.Init(); }
 
  private:
-  ShardedMap<gzFile, std::unique_ptr<GzipFile>> map;
+  ShardedMap<gzFile, std::shared_ptr<GzipFile>> map;
 };
 GzipFiles gzip_files;
 
@@ -1120,7 +1120,7 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
 }
 
 int ZEXPORT gzwrite(gzFile file, voidpc buf, unsigned len) {
-  GzipFile* gz = gzip_files.Get(file);
+  auto gz = gzip_files.Get(file);
   Log(LogLevel::LOG_INFO, "gzwrite Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
 
@@ -1149,7 +1149,7 @@ int ZEXPORT gzwrite(gzFile file, voidpc buf, unsigned len) {
 
       // Compress and write the buffer
       if (written_bytes < len) {
-        int ret = CompressAndWrite(file, gz);
+        int ret = CompressAndWrite(file, gz.get());
         if (ret != 0) {
           written_bytes = 0;
           goto gzwrite_end;
@@ -1177,7 +1177,7 @@ gzwrite_end:
 }
 
 int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
-  GzipFile* gz = gzip_files.Get(file);
+  auto gz = gzip_files.Get(file);
 
   Log(LogLevel::LOG_INFO, "gzread Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
@@ -1248,8 +1248,9 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
           uint8_t* output = reinterpret_cast<uint8_t*>(gz->data_buf);
           if (!gz->use_zlib_for_decompression) {
             bool end_of_stream = false;
-            ret = GzreadAcceleratorUncompress(gz, input, &input_len, output,
-                                              &output_len, &end_of_stream);
+            ret =
+                GzreadAcceleratorUncompress(gz.get(), input, &input_len, output,
+                                            &output_len, &end_of_stream);
             Log(LogLevel::LOG_INFO, "gzread Line ", __LINE__, ", file ",
                 static_cast<void*>(file), ", accelerator return code ", ret,
                 ", input ", input_len, ", output ", output_len, "\n");
@@ -1320,7 +1321,7 @@ gzread_end:
 }
 
 int ZEXPORT gzclose(gzFile file) {
-  GzipFile* gz = gzip_files.Get(file);
+  auto gz = gzip_files.Get(file);
 
   Log(LogLevel::LOG_INFO, "gzclose Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buffered ", gz->data_buf_content, ", path ",
@@ -1332,7 +1333,7 @@ int ZEXPORT gzclose(gzFile file) {
     // Compress any remaining buffered data
     int write_ret = 0;
     if (gz->data_buf_content > 0) {
-      write_ret = CompressAndWrite(file, gz);
+      write_ret = CompressAndWrite(file, gz.get());
     }
 
     // Capture file size and name before gzclose
@@ -1377,7 +1378,7 @@ int ZEXPORT gzclose(gzFile file) {
 }
 
 int ZEXPORT gzeof(gzFile file) {
-  GzipFile* gz = gzip_files.Get(file);
+  auto gz = gzip_files.Get(file);
   return gz->reached_eof;
 }
 #if defined(__clang__)


### PR DESCRIPTION
- Validate the dest_size extracted from the gzip-ext header in DetectGzipExt(). Reject the header when dest_size + HDRFTR_SIZE would exceed the input buffer length, preventing an OOB read by QPL/QATzip on malformed or malicious input.

- Change ShardedMap from storing unique_ptr to shared_ptr and return a shared_ptr copy from Get(). The caller now holds a refcounted handle that keeps the object alive for the duration of its use, eliminating use-after-free when a concurrent deflateEnd/inflateEnd or address-reuse scenario destroys the map entry.

- Update ShardedMap tests to use shared_ptr accordingly.