### PR TITLE
Fix null-pointer dereferences and partial-init failure

### DIFF
--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1320,6 +1320,145 @@ TEST_F(ConfigLoaderTest, MapShardsInvalidNonPowerOfTwo) {
   SetConfig(MAP_SHARDS, saved_shards);
 }
 
+// The shim keeps per-stream state in maps keyed by z_streamp, and every entry
+// point that consumes that state has to cope with the entry being absent. That
+// happens whenever an init call did not register anything: an app that ignores
+// a failed *Init return code and keeps using the stream, a stream that was
+// never initialized at all, or a gzFile the shim never saw. Before these
+// guards existed each of those cases dereferenced a null shared_ptr.
+class UnregisteredStreamTest : public ::testing::Test {};
+
+TEST_F(UnregisteredStreamTest, DeflateAfterFailedInitDoesNotCrash) {
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+
+  // window_bits is invalid, so zlib rejects the stream and the shim registers
+  // no settings for it.
+  ASSERT_EQ(deflateInit2(&strm, 6, Z_DEFLATED, 99, 8, Z_DEFAULT_STRATEGY),
+            Z_STREAM_ERROR);
+
+  std::vector<uint8_t> input(1024, 'a');
+  std::vector<uint8_t> output(4096, 0);
+  strm.next_in = input.data();
+  strm.avail_in = static_cast<uInt>(input.size());
+  strm.next_out = output.data();
+  strm.avail_out = static_cast<uInt>(output.size());
+
+  // An app that ignores the failed init and calls deflate anyway must get
+  // zlib's error back rather than a segfault.
+  EXPECT_EQ(deflate(&strm, Z_FINISH), Z_STREAM_ERROR);
+  EXPECT_EQ(GetDeflateExecutionPath(&strm), ZLIB);
+}
+
+TEST_F(UnregisteredStreamTest, InflateAfterFailedInitDoesNotCrash) {
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+
+  ASSERT_EQ(inflateInit2(&strm, 99), Z_STREAM_ERROR);
+
+  std::vector<uint8_t> input(1024, 0);
+  std::vector<uint8_t> output(4096, 0);
+  strm.next_in = input.data();
+  strm.avail_in = static_cast<uInt>(input.size());
+  strm.next_out = output.data();
+  strm.avail_out = static_cast<uInt>(output.size());
+
+  EXPECT_EQ(inflate(&strm, Z_FINISH), Z_STREAM_ERROR);
+  EXPECT_EQ(GetInflateExecutionPath(&strm), ZLIB);
+}
+
+// A stream the shim has never seen at all. Reset/SetDictionary/End have to
+// tolerate the missing entry too, not just deflate/inflate.
+TEST_F(UnregisteredStreamTest, UnknownStreamIsReportedAsZlibPath) {
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+
+  EXPECT_EQ(GetDeflateExecutionPath(&strm), ZLIB);
+  EXPECT_EQ(GetInflateExecutionPath(&strm), ZLIB);
+}
+
+TEST_F(UnregisteredStreamTest, ResetAndEndOnUnregisteredStream) {
+  z_stream deflate_strm;
+  memset(&deflate_strm, 0, sizeof(deflate_strm));
+  EXPECT_EQ(deflateReset(&deflate_strm), Z_STREAM_ERROR);
+  EXPECT_EQ(deflateEnd(&deflate_strm), Z_STREAM_ERROR);
+
+  z_stream inflate_strm;
+  memset(&inflate_strm, 0, sizeof(inflate_strm));
+  EXPECT_EQ(inflateReset(&inflate_strm), Z_STREAM_ERROR);
+  EXPECT_EQ(inflateEnd(&inflate_strm), Z_STREAM_ERROR);
+}
+
+TEST_F(UnregisteredStreamTest, SetDictionaryOnUnregisteredStream) {
+  const uint32_t saved = GetConfig(IGNORE_ZLIB_DICTIONARY);
+  SetConfig(IGNORE_ZLIB_DICTIONARY, 0);
+
+  std::vector<uint8_t> dict(64, 'd');
+
+  z_stream deflate_strm;
+  memset(&deflate_strm, 0, sizeof(deflate_strm));
+  EXPECT_EQ(deflateSetDictionary(&deflate_strm, dict.data(),
+                                 static_cast<uInt>(dict.size())),
+            Z_STREAM_ERROR);
+
+  z_stream inflate_strm;
+  memset(&inflate_strm, 0, sizeof(inflate_strm));
+  EXPECT_EQ(inflateSetDictionary(&inflate_strm, dict.data(),
+                                 static_cast<uInt>(dict.size())),
+            Z_STREAM_ERROR);
+
+  SetConfig(IGNORE_ZLIB_DICTIONARY, saved);
+}
+
+// A stream that fails to init, is then successfully re-initialized, must end up
+// registered and usable — the failed attempt must not leave the shim confused
+// about the stream.
+TEST_F(UnregisteredStreamTest, ReinitAfterFailedInitWorks) {
+  z_stream strm;
+  memset(&strm, 0, sizeof(strm));
+
+  ASSERT_EQ(deflateInit2(&strm, 6, Z_DEFLATED, 99, 8, Z_DEFAULT_STRATEGY),
+            Z_STREAM_ERROR);
+  ASSERT_EQ(deflateInit2(&strm, 6, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY),
+            Z_OK);
+
+  std::vector<uint8_t> input(4096, 'a');
+  std::vector<uint8_t> compressed(8192, 0);
+  strm.next_in = input.data();
+  strm.avail_in = static_cast<uInt>(input.size());
+  strm.next_out = compressed.data();
+  strm.avail_out = static_cast<uInt>(compressed.size());
+  ASSERT_EQ(deflate(&strm, Z_FINISH), Z_STREAM_END);
+  const size_t compressed_size = compressed.size() - strm.avail_out;
+  ASSERT_EQ(deflateEnd(&strm), Z_OK);
+
+  // Round-trip to confirm the stream really was functional, not just non-fatal.
+  z_stream d;
+  memset(&d, 0, sizeof(d));
+  ASSERT_EQ(inflateInit2(&d, 31), Z_OK);
+  std::vector<uint8_t> decompressed(input.size(), 0);
+  d.next_in = compressed.data();
+  d.avail_in = static_cast<uInt>(compressed_size);
+  d.next_out = decompressed.data();
+  d.avail_out = static_cast<uInt>(decompressed.size());
+  EXPECT_EQ(inflate(&d, Z_FINISH), Z_STREAM_END);
+  EXPECT_EQ(inflateEnd(&d), Z_OK);
+  EXPECT_EQ(decompressed, input);
+}
+
+// gzFile entry points on a handle the shim never registered. nullptr is the
+// simplest such handle and is what gzopen returns on failure, so an app that
+// ignores that failure reaches exactly this path.
+TEST_F(UnregisteredStreamTest, GzFunctionsOnUnregisteredFile) {
+  std::vector<uint8_t> buf(64, 0);
+
+  // These match what plain zlib returns for a file it cannot act on.
+  EXPECT_EQ(gzeof(nullptr), 0);
+  EXPECT_EQ(gzread(nullptr, buf.data(), static_cast<unsigned>(buf.size())), -1);
+  EXPECT_EQ(gzwrite(nullptr, buf.data(), static_cast<unsigned>(buf.size())), 0);
+  EXPECT_EQ(gzclose(nullptr), Z_STREAM_ERROR);
+}
+
 class ShardedMapTest : public ::testing::Test {};
 
 TEST_F(ShardedMapTest, BasicSetAndGet) {

--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1321,19 +1321,20 @@ TEST_F(ConfigLoaderTest, MapShardsInvalidNonPowerOfTwo) {
 }
 
 // The shim keeps per-stream state in maps keyed by z_streamp, and every entry
-// point that consumes that state has to cope with the entry being absent. That
-// happens whenever an init call did not register anything: an app that ignores
-// a failed *Init return code and keeps using the stream, a stream that was
-// never initialized at all, or a gzFile the shim never saw. Before these
-// guards existed each of those cases dereferenced a null shared_ptr.
+// point that consumes that state has to cope with the entry being absent: a
+// stream that was never initialized at all, one whose *Init failed, or a
+// gzFile the shim never saw. Before these guards existed each of those cases
+// dereferenced a null shared_ptr.
 class UnregisteredStreamTest : public ::testing::Test {};
 
 TEST_F(UnregisteredStreamTest, DeflateAfterFailedInitDoesNotCrash) {
   z_stream strm;
   memset(&strm, 0, sizeof(strm));
 
-  // window_bits is invalid, so zlib rejects the stream and the shim registers
-  // no settings for it.
+  // window_bits is invalid, so zlib rejects the stream. The shim registers
+  // settings before delegating, so an entry does exist here — what matters is
+  // that deflate() on a stream zlib never initialized still reports zlib's
+  // error instead of trusting that state.
   ASSERT_EQ(deflateInit2(&strm, 6, Z_DEFLATED, 99, 8, Z_DEFAULT_STRATEGY),
             Z_STREAM_ERROR);
 

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -76,7 +76,11 @@ static void InitStreamRegistries();
 static int init_zlib_accel(void) __attribute__((constructor));
 static void cleanup_zlib_accel(void) __attribute__((destructor));
 
-// Macro that load symbols with error checking
+// When true, all wrappers fall through to orig_* without acceleration.
+static bool shim_disabled = false;
+
+// Macro that loads symbols — logs errors but continues loading remaining
+// symbols so that as many orig_* pointers as possible are resolved.
 #define LOAD_SYMBOL(fptr, type, name)                                          \
   do {                                                                         \
     dlerror();                                                                 \
@@ -85,12 +89,11 @@ static void cleanup_zlib_accel(void) __attribute__((destructor));
     if (error != nullptr) {                                                    \
       Log(LogLevel::LOG_ERROR, "init_zlib_accel Line ", __LINE__,              \
           "Failed to load symbol '", name, "': ", error, "\n");                \
-      return 1;                                                                \
-    }                                                                          \
-    if (fptr == nullptr) {                                                     \
+      shim_disabled = true;                                                    \
+    } else if (fptr == nullptr) {                                              \
       Log(LogLevel::LOG_ERROR, "init_zlib_accel Line ", __LINE__, " Symbol '", \
           name, "' resolved to NULL\n");                                       \
-      return 1;                                                                \
+      shim_disabled = true;                                                    \
     }                                                                          \
   } while (0)
 
@@ -275,7 +278,9 @@ int ZEXPORT deflateSetDictionary(z_streamp strm, const Bytef* dictionary,
     Log(LogLevel::LOG_INFO, "deflateSetDictionary Line ", __LINE__, ", strm ",
         static_cast<void*>(strm), ", dictLength ", dictLength, "\n");
     auto deflate_settings = deflate_stream_settings.Get(strm);
-    deflate_settings->path = ZLIB;
+    if (deflate_settings != nullptr) {
+      deflate_settings->path = ZLIB;
+    }
     return orig_deflateSetDictionary(strm, dictionary, dictLength);
   }
   Log(LogLevel::LOG_INFO, "deflateSetDictionary Line ", __LINE__,
@@ -288,6 +293,10 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
   auto deflate_settings = deflate_stream_settings.Get(strm);
   INCREMENT_STAT(DEFLATE_COUNT);
   PrintStats();
+
+  if (deflate_settings == nullptr || shim_disabled) {
+    return orig_deflate(strm, flush);
+  }
 
   Log(LogLevel::LOG_INFO, "deflate Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), ", avail_in ", strm->avail_in, ", avail_out ",
@@ -448,6 +457,10 @@ int ZEXPORT inflate(z_streamp strm, int flush) {
   auto inflate_settings = inflate_stream_settings.Get(strm);
   INCREMENT_STAT(INFLATE_COUNT);
   PrintStats();
+
+  if (inflate_settings == nullptr || shim_disabled) {
+    return orig_inflate(strm, flush);
+  }
 
   Log(LogLevel::LOG_INFO, "inflate Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), ", avail_in ", strm->avail_in, ", avail_out ",
@@ -742,11 +755,17 @@ int ZEXPORT uncompress(Bytef* dest, uLongf* destLen, const Bytef* source,
 
 ExecutionPath GetDeflateExecutionPath(z_streamp strm) {
   auto deflate_settings = deflate_stream_settings.Get(strm);
+  if (deflate_settings == nullptr) {
+    return ZLIB;
+  }
   return deflate_settings->path;
 }
 
 ExecutionPath GetInflateExecutionPath(z_streamp strm) {
   auto inflate_settings = inflate_stream_settings.Get(strm);
+  if (inflate_settings == nullptr) {
+    return ZLIB;
+  }
   return inflate_settings->path;
 }
 
@@ -1127,6 +1146,9 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
 
 int ZEXPORT gzwrite(gzFile file, voidpc buf, unsigned len) {
   auto gz = gzip_files.Get(file);
+  if (gz == nullptr || shim_disabled) {
+    return orig_gzwrite(file, buf, len);
+  }
   Log(LogLevel::LOG_INFO, "gzwrite Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
 
@@ -1184,6 +1206,9 @@ gzwrite_end:
 
 int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
   auto gz = gzip_files.Get(file);
+  if (gz == nullptr || shim_disabled) {
+    return orig_gzread(file, buf, len);
+  }
 
   Log(LogLevel::LOG_INFO, "gzread Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
@@ -1328,6 +1353,9 @@ gzread_end:
 
 int ZEXPORT gzclose(gzFile file) {
   auto gz = gzip_files.Get(file);
+  if (gz == nullptr || shim_disabled) {
+    return orig_gzclose(file);
+  }
 
   // Unregister up front, before orig_gzclose frees the gzFile. Unsetting after
   // the free would erase the entry of whatever file has since been allocated at
@@ -1389,6 +1417,9 @@ int ZEXPORT gzclose(gzFile file) {
 
 int ZEXPORT gzeof(gzFile file) {
   auto gz = gzip_files.Get(file);
+  if (gz == nullptr || shim_disabled) {
+    return orig_gzeof(file);
+  }
   return gz->reached_eof;
 }
 #if defined(__clang__)

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -76,11 +76,15 @@ static void InitStreamRegistries();
 static int init_zlib_accel(void) __attribute__((constructor));
 static void cleanup_zlib_accel(void) __attribute__((destructor));
 
-// When true, all wrappers fall through to orig_* without acceleration.
-static bool shim_disabled = false;
+// Number of orig_* symbols that failed to resolve. Only used for the summary
+// log below: each wrapper checks the specific pointer it needs, so one missing
+// symbol degrades only the paths that actually call it.
+static int missing_symbol_count = 0;
 
-// Macro that loads symbols — logs errors but continues loading remaining
-// symbols so that as many orig_* pointers as possible are resolved.
+// Macro that loads symbols. A failure is logged but does not stop the sequence:
+// returning early from the constructor would leave every later orig_* pointer
+// null (and the return value of a constructor is ignored anyway), so keep going
+// and resolve as many as possible.
 #define LOAD_SYMBOL(fptr, type, name)                                          \
   do {                                                                         \
     dlerror();                                                                 \
@@ -89,11 +93,12 @@ static bool shim_disabled = false;
     if (error != nullptr) {                                                    \
       Log(LogLevel::LOG_ERROR, "init_zlib_accel Line ", __LINE__,              \
           "Failed to load symbol '", name, "': ", error, "\n");                \
-      shim_disabled = true;                                                    \
+      fptr = nullptr;                                                          \
+      missing_symbol_count++;                                                  \
     } else if (fptr == nullptr) {                                              \
       Log(LogLevel::LOG_ERROR, "init_zlib_accel Line ", __LINE__, " Symbol '", \
           name, "' resolved to NULL\n");                                       \
-      shim_disabled = true;                                                    \
+      missing_symbol_count++;                                                  \
     }                                                                          \
   } while (0)
 
@@ -156,6 +161,13 @@ static int init_zlib_accel(void) {
   LOAD_SYMBOL(orig_gzclose, int (*)(gzFile), "gzclose");
 
   LOAD_SYMBOL(orig_gzeof, int (*)(gzFile), "gzeof");
+
+  if (missing_symbol_count > 0) {
+    Log(LogLevel::LOG_ERROR, "init_zlib_accel Line ", __LINE__, " ",
+        missing_symbol_count,
+        " zlib symbol(s) could not be resolved; the affected entry points fall "
+        "back to zlib where possible and return Z_VERSION_ERROR where not\n");
+  }
 
   // Load configuration file; on failure (file absent or is a symlink) continue
   // with compiled-in defaults — a missing config is not fatal.
@@ -254,6 +266,14 @@ int ZEXPORT deflateInit_(z_streamp strm, int level, const char* version,
   Log(LogLevel::LOG_INFO, "deflateInit_ Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), ", level ", level, "\n");
 
+  // The shim has no deflate implementation of its own, so a missing symbol is
+  // unrecoverable for this entry point. Report it the way zlib reports an
+  // unusable library and register nothing, which keeps deflate() off this
+  // stream.
+  if (orig_deflateInit_ == nullptr) {
+    return Z_VERSION_ERROR;
+  }
+
   deflate_stream_settings.Set(strm, level, Z_DEFLATED, 15, 8,
                               Z_DEFAULT_STRATEGY);
   return orig_deflateInit_(strm, level, version, stream_size);
@@ -265,6 +285,10 @@ int ZEXPORT deflateInit2_(z_streamp strm, int level, int method,
   Log(LogLevel::LOG_INFO, "deflateInit2_ Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), ", level ", level, ", window_bits ",
       window_bits, " \n");
+
+  if (orig_deflateInit2_ == nullptr) {
+    return Z_VERSION_ERROR;
+  }
 
   deflate_stream_settings.Set(strm, level, method, window_bits, mem_level,
                               strategy);
@@ -281,7 +305,9 @@ int ZEXPORT deflateSetDictionary(z_streamp strm, const Bytef* dictionary,
     if (deflate_settings != nullptr) {
       deflate_settings->path = ZLIB;
     }
-    return orig_deflateSetDictionary(strm, dictionary, dictLength);
+    return orig_deflateSetDictionary != nullptr
+               ? orig_deflateSetDictionary(strm, dictionary, dictLength)
+               : Z_VERSION_ERROR;
   }
   Log(LogLevel::LOG_INFO, "deflateSetDictionary Line ", __LINE__,
       " ignored because ignore_zlib_dictionary is set to ",
@@ -294,8 +320,11 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
   INCREMENT_STAT(DEFLATE_COUNT);
   PrintStats();
 
-  if (deflate_settings == nullptr || shim_disabled) {
-    return orig_deflate(strm, flush);
+  // Without per-stream settings there is nothing to base a path decision on, so
+  // hand the call straight to zlib.
+  if (deflate_settings == nullptr) {
+    return orig_deflate != nullptr ? orig_deflate(strm, flush)
+                                   : Z_VERSION_ERROR;
   }
 
   Log(LogLevel::LOG_INFO, "deflate Line ", __LINE__, ", strm ",
@@ -384,7 +413,7 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
     }
   }
 
-  if (in_call || configs[USE_ZLIB_COMPRESS]) {
+  if ((in_call || configs[USE_ZLIB_COMPRESS]) && orig_deflate != nullptr) {
     ret = orig_deflate(strm, flush);
     INCREMENT_STAT(DEFLATE_ZLIB_COUNT);
     if (!in_call) {
@@ -407,7 +436,7 @@ int ZEXPORT deflateEnd(z_streamp strm) {
   Log(LogLevel::LOG_INFO, "deflateEnd Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), "\n");
   deflate_stream_settings.Unset(strm);
-  return orig_deflateEnd(strm);
+  return orig_deflateEnd != nullptr ? orig_deflateEnd(strm) : Z_VERSION_ERROR;
 }
 
 int ZEXPORT deflateReset(z_streamp strm) {
@@ -418,23 +447,32 @@ int ZEXPORT deflateReset(z_streamp strm) {
     deflate_settings->path = UNDEFINED;
   }
 
-  return orig_deflateReset(strm);
+  return orig_deflateReset != nullptr ? orig_deflateReset(strm)
+                                      : Z_VERSION_ERROR;
 }
 
 int ZEXPORT inflateInit_(z_streamp strm, const char* version, int stream_size) {
-  inflate_stream_settings.Set(strm, 15);
   Log(LogLevel::LOG_INFO, "inflateInit_ Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), "\n");
 
+  if (orig_inflateInit_ == nullptr) {
+    return Z_VERSION_ERROR;
+  }
+
+  inflate_stream_settings.Set(strm, 15);
   return orig_inflateInit_(strm, version, stream_size);
 }
 
 int ZEXPORT inflateInit2_(z_streamp strm, int window_bits, const char* version,
                           int stream_size) {
-  inflate_stream_settings.Set(strm, window_bits);
   Log(LogLevel::LOG_INFO, "inflateInit2_ Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), ", window_bits ", window_bits, "\n");
 
+  if (orig_inflateInit2_ == nullptr) {
+    return Z_VERSION_ERROR;
+  }
+
+  inflate_stream_settings.Set(strm, window_bits);
   return orig_inflateInit2_(strm, window_bits, version, stream_size);
 }
 
@@ -447,7 +485,9 @@ int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef* dictionary,
     if (inflate_settings != nullptr) {
       inflate_settings->path = ZLIB;
     }
-    return orig_inflateSetDictionary(strm, dictionary, dictLength);
+    return orig_inflateSetDictionary != nullptr
+               ? orig_inflateSetDictionary(strm, dictionary, dictLength)
+               : Z_VERSION_ERROR;
   }
   Log(LogLevel::LOG_INFO, "inflateSetDictionary Line ", __LINE__,
       " ignored because ignore_zlib_dictionary is set to ",
@@ -460,8 +500,11 @@ int ZEXPORT inflate(z_streamp strm, int flush) {
   INCREMENT_STAT(INFLATE_COUNT);
   PrintStats();
 
-  if (inflate_settings == nullptr || shim_disabled) {
-    return orig_inflate(strm, flush);
+  // Without per-stream settings there is nothing to base a path decision on, so
+  // hand the call straight to zlib.
+  if (inflate_settings == nullptr) {
+    return orig_inflate != nullptr ? orig_inflate(strm, flush)
+                                   : Z_VERSION_ERROR;
   }
 
   Log(LogLevel::LOG_INFO, "inflate Line ", __LINE__, ", strm ",
@@ -569,7 +612,7 @@ int ZEXPORT inflate(z_streamp strm, int flush) {
     }
   }
 
-  if (in_call || configs[USE_ZLIB_UNCOMPRESS]) {
+  if ((in_call || configs[USE_ZLIB_UNCOMPRESS]) && orig_inflate != nullptr) {
     ret = orig_inflate(strm, flush);
     INCREMENT_STAT(INFLATE_ZLIB_COUNT);
     if (!in_call) {
@@ -592,7 +635,7 @@ int ZEXPORT inflateEnd(z_streamp strm) {
   Log(LogLevel::LOG_INFO, "inflateEnd Line ", __LINE__, ", strm ",
       static_cast<void*>(strm), "\n");
   inflate_stream_settings.Unset(strm);
-  return orig_inflateEnd(strm);
+  return orig_inflateEnd != nullptr ? orig_inflateEnd(strm) : Z_VERSION_ERROR;
 }
 
 int ZEXPORT inflateReset(z_streamp strm) {
@@ -603,7 +646,8 @@ int ZEXPORT inflateReset(z_streamp strm) {
     inflate_settings->path = UNDEFINED;
   }
 
-  return orig_inflateReset(strm);
+  return orig_inflateReset != nullptr ? orig_inflateReset(strm)
+                                      : Z_VERSION_ERROR;
 }
 
 int ZEXPORT compress2(Bytef* dest, uLongf* destLen, const Bytef* source,
@@ -657,7 +701,7 @@ int ZEXPORT compress2(Bytef* dest, uLongf* destLen, const Bytef* source,
     Log(LogLevel::LOG_INFO, "compress2 Line ", __LINE__,
         ", accelerator return code ", ret, ", sourceLen ", sourceLen,
         ", destLen ", *destLen, "\n");
-  } else if (configs[USE_ZLIB_COMPRESS]) {
+  } else if (configs[USE_ZLIB_COMPRESS] && orig_compress2 != nullptr) {
     // compress2 in zlib calls deflate. It was observed that deflate is
     // sometimes intercepted by the shim. in_call prevents deflate from using
     // accelerators.
@@ -735,7 +779,7 @@ int ZEXPORT uncompress2(Bytef* dest, uLongf* destLen, const Bytef* source,
     Log(LogLevel::LOG_INFO, "uncompress2 Line ", __LINE__,
         ", accelerator return code ", ret, ", sourceLen ", *sourceLen,
         ", destLen ", *destLen, "\n");
-  } else if (configs[USE_ZLIB_UNCOMPRESS]) {
+  } else if (configs[USE_ZLIB_UNCOMPRESS] && orig_uncompress2 != nullptr) {
     // refer to comment in compress2
     in_call = true;
     ret = orig_uncompress2(dest, destLen, source, sourceLen);
@@ -785,8 +829,12 @@ struct GzipFile {
     if (io_buf != nullptr) {
       delete[] io_buf;
     }
-    orig_deflateEnd(&deflate_stream);
-    orig_inflateEnd(&inflate_stream);
+    if (orig_deflateEnd != nullptr) {
+      orig_deflateEnd(&deflate_stream);
+    }
+    if (orig_inflateEnd != nullptr) {
+      orig_inflateEnd(&inflate_stream);
+    }
   }
 
   void Reset() {
@@ -800,11 +848,16 @@ struct GzipFile {
     io_buf_content = 0;
 
     memset(&deflate_stream, 0, sizeof(z_stream));
-    orig_deflateInit2_(&deflate_stream, -1, Z_DEFLATED, 31, 8,
-                       Z_DEFAULT_STRATEGY, ZLIB_VERSION, (int)sizeof(z_stream));
+    if (orig_deflateInit2_ != nullptr) {
+      orig_deflateInit2_(&deflate_stream, -1, Z_DEFLATED, 31, 8,
+                         Z_DEFAULT_STRATEGY, ZLIB_VERSION,
+                         (int)sizeof(z_stream));
+    }
     memset(&inflate_stream, 0, sizeof(z_stream));
-    orig_inflateInit2_(&inflate_stream, 31, ZLIB_VERSION,
-                       (int)sizeof(z_stream));
+    if (orig_inflateInit2_ != nullptr) {
+      orig_inflateInit2_(&inflate_stream, 31, ZLIB_VERSION,
+                         (int)sizeof(z_stream));
+    }
   }
 
   void AllocateBuffers() {
@@ -941,6 +994,9 @@ int GetOpenFlags(const char* mode, FileMode* file_mode) {
 gzFile ZEXPORT gzopen(const char* path, const char* mode) {
   // We need to store the file descriptor for use in other functions.
   // Open the file here and then call gzdopen
+  if (orig_gzdopen == nullptr) {
+    return nullptr;
+  }
   FileMode file_mode = FileMode::NONE;
   int oflag = GetOpenFlags(mode, &file_mode);
   int fd = open((const char*)path, oflag, 0666);
@@ -961,6 +1017,9 @@ gzFile ZEXPORT gzopen(const char* path, const char* mode) {
 }
 
 gzFile ZEXPORT gzdopen(int fd, const char* mode) {
+  if (orig_gzdopen == nullptr) {
+    return nullptr;
+  }
   gzFile file = orig_gzdopen(fd, mode);
 
   Log(LogLevel::LOG_INFO, "gzdopen Line ", __LINE__, ", file ", fd, ", fd ",
@@ -1075,7 +1134,7 @@ static int GzreadAcceleratorUncompress(GzipFile* gz, uint8_t* input,
 
 static int GzwriteZlibCompress(gzFile file, voidpc buf, unsigned len) {
   int ret = 0;
-  if (configs[USE_ZLIB_COMPRESS]) {
+  if (configs[USE_ZLIB_COMPRESS] && orig_gzwrite != nullptr) {
     ret = orig_gzwrite(file, buf, len);
   } else {
     ret = 0;
@@ -1085,7 +1144,7 @@ static int GzwriteZlibCompress(gzFile file, voidpc buf, unsigned len) {
 
 static int GzreadZlibUncompress(gzFile file, voidp buf, unsigned len) {
   int ret = 0;
-  if (configs[USE_ZLIB_UNCOMPRESS]) {
+  if (configs[USE_ZLIB_UNCOMPRESS] && orig_gzread != nullptr) {
     ret = orig_gzread(file, buf, len);
   } else {
     ret = -1;
@@ -1108,6 +1167,9 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
 
   if (ret == 0) {
     gz->data_buf_pos = input_len;
+  } else if (orig_deflate == nullptr) {
+    // No accelerator result and no zlib to fall back to.
+    return 1;
   } else {
     gz->deflate_stream.next_in = (Bytef*)(gz->data_buf);
     gz->deflate_stream.avail_in =
@@ -1123,7 +1185,9 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
     if (ret == Z_STREAM_END) {
       gz->data_buf_pos = gz->data_buf_content - gz->deflate_stream.avail_in;
       output_len = gz->io_buf_size - gz->deflate_stream.avail_out;
-      orig_deflateReset(&gz->deflate_stream);
+      if (orig_deflateReset != nullptr) {
+        orig_deflateReset(&gz->deflate_stream);
+      }
     } else {
       return 1;
     }
@@ -1148,8 +1212,8 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
 
 int ZEXPORT gzwrite(gzFile file, voidpc buf, unsigned len) {
   auto gz = gzip_files.Get(file);
-  if (gz == nullptr || shim_disabled) {
-    return orig_gzwrite(file, buf, len);
+  if (gz == nullptr) {
+    return orig_gzwrite != nullptr ? orig_gzwrite(file, buf, len) : 0;
   }
   Log(LogLevel::LOG_INFO, "gzwrite Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
@@ -1208,8 +1272,8 @@ gzwrite_end:
 
 int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
   auto gz = gzip_files.Get(file);
-  if (gz == nullptr || shim_disabled) {
-    return orig_gzread(file, buf, len);
+  if (gz == nullptr) {
+    return orig_gzread != nullptr ? orig_gzread(file, buf, len) : -1;
   }
 
   Log(LogLevel::LOG_INFO, "gzread Line ", __LINE__, ", file ",
@@ -1301,6 +1365,11 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
             }
           }
 
+          if (gz->use_zlib_for_decompression && orig_inflate == nullptr) {
+            read_bytes = -1;
+            goto gzread_end;
+          }
+
           if (gz->use_zlib_for_decompression) {
             gz->inflate_stream.next_in = (Bytef*)(gz->io_buf);
             gz->inflate_stream.avail_in =
@@ -1319,7 +1388,7 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
                   (gz->io_buf_content - gz->inflate_stream.avail_in);
               gz->data_buf_content +=
                   (gz->data_buf_size - gz->inflate_stream.avail_out);
-              if (ret == Z_STREAM_END) {
+              if (ret == Z_STREAM_END && orig_inflateReset != nullptr) {
                 orig_inflateReset(&gz->inflate_stream);
               }
             } else if (ret != Z_OK) {
@@ -1355,8 +1424,12 @@ gzread_end:
 
 int ZEXPORT gzclose(gzFile file) {
   auto gz = gzip_files.Get(file);
-  if (gz == nullptr || shim_disabled) {
-    return orig_gzclose(file);
+  if (gz == nullptr || orig_gzclose == nullptr) {
+    // Every path below ends in orig_gzclose, so without it there is nothing
+    // useful to do; leave the entry in place rather than losing the state of a
+    // file that stays open. Z_STREAM_ERROR matches what zlib's own gzclose
+    // returns for a file it cannot act on.
+    return orig_gzclose != nullptr ? orig_gzclose(file) : Z_STREAM_ERROR;
   }
 
   // Unregister up front, before orig_gzclose frees the gzFile. Unsetting after
@@ -1419,8 +1492,8 @@ int ZEXPORT gzclose(gzFile file) {
 
 int ZEXPORT gzeof(gzFile file) {
   auto gz = gzip_files.Get(file);
-  if (gz == nullptr || shim_disabled) {
-    return orig_gzeof(file);
+  if (gz == nullptr) {
+    return orig_gzeof != nullptr ? orig_gzeof(file) : 0;
   }
   return gz->reached_eof;
 }

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -444,7 +444,9 @@ int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef* dictionary,
     Log(LogLevel::LOG_INFO, "inflateSetDictionary Line ", __LINE__, ", strm ",
         static_cast<void*>(strm), "dictLength ", dictLength, "\n");
     auto inflate_settings = inflate_stream_settings.Get(strm);
-    inflate_settings->path = ZLIB;
+    if (inflate_settings != nullptr) {
+      inflate_settings->path = ZLIB;
+    }
     return orig_inflateSetDictionary(strm, dictionary, dictLength);
   }
   Log(LogLevel::LOG_INFO, "inflateSetDictionary Line ", __LINE__,

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -413,11 +413,17 @@ int ZEXPORT deflate(z_streamp strm, int flush) {
     }
   }
 
-  if ((in_call || configs[USE_ZLIB_COMPRESS]) && orig_deflate != nullptr) {
-    ret = orig_deflate(strm, flush);
-    INCREMENT_STAT(DEFLATE_ZLIB_COUNT);
-    if (!in_call) {
-      deflate_settings->path = ZLIB;
+  if (in_call || configs[USE_ZLIB_COMPRESS]) {
+    // Distinguish "no zlib to delegate to" from "zlib rejected the data": the
+    // former is an unusable library, not a data problem.
+    if (orig_deflate == nullptr) {
+      ret = Z_VERSION_ERROR;
+    } else {
+      ret = orig_deflate(strm, flush);
+      INCREMENT_STAT(DEFLATE_ZLIB_COUNT);
+      if (!in_call) {
+        deflate_settings->path = ZLIB;
+      }
     }
   } else {
     ret = Z_DATA_ERROR;
@@ -612,11 +618,16 @@ int ZEXPORT inflate(z_streamp strm, int flush) {
     }
   }
 
-  if ((in_call || configs[USE_ZLIB_UNCOMPRESS]) && orig_inflate != nullptr) {
-    ret = orig_inflate(strm, flush);
-    INCREMENT_STAT(INFLATE_ZLIB_COUNT);
-    if (!in_call) {
-      inflate_settings->path = ZLIB;
+  if (in_call || configs[USE_ZLIB_UNCOMPRESS]) {
+    // refer to comment in deflate
+    if (orig_inflate == nullptr) {
+      ret = Z_VERSION_ERROR;
+    } else {
+      ret = orig_inflate(strm, flush);
+      INCREMENT_STAT(INFLATE_ZLIB_COUNT);
+      if (!in_call) {
+        inflate_settings->path = ZLIB;
+      }
     }
   } else {
     ret = Z_DATA_ERROR;
@@ -701,15 +712,21 @@ int ZEXPORT compress2(Bytef* dest, uLongf* destLen, const Bytef* source,
     Log(LogLevel::LOG_INFO, "compress2 Line ", __LINE__,
         ", accelerator return code ", ret, ", sourceLen ", sourceLen,
         ", destLen ", *destLen, "\n");
-  } else if (configs[USE_ZLIB_COMPRESS] && orig_compress2 != nullptr) {
-    // compress2 in zlib calls deflate. It was observed that deflate is
-    // sometimes intercepted by the shim. in_call prevents deflate from using
-    // accelerators.
-    in_call = true;
-    ret = orig_compress2(dest, destLen, source, sourceLen, level);
-    in_call = false;
-    Log(LogLevel::LOG_INFO, "compress2 Line ", __LINE__, ", zlib return code ",
-        ret, ", sourceLen ", sourceLen, ", destLen ", *destLen, "\n");
+  } else if (configs[USE_ZLIB_COMPRESS]) {
+    // refer to comment in deflate
+    if (orig_compress2 == nullptr) {
+      ret = Z_VERSION_ERROR;
+    } else {
+      // compress2 in zlib calls deflate. It was observed that deflate is
+      // sometimes intercepted by the shim. in_call prevents deflate from using
+      // accelerators.
+      in_call = true;
+      ret = orig_compress2(dest, destLen, source, sourceLen, level);
+      in_call = false;
+      Log(LogLevel::LOG_INFO, "compress2 Line ", __LINE__,
+          ", zlib return code ", ret, ", sourceLen ", sourceLen, ", destLen ",
+          *destLen, "\n");
+    }
   } else {
     ret = Z_DATA_ERROR;
   }
@@ -779,14 +796,19 @@ int ZEXPORT uncompress2(Bytef* dest, uLongf* destLen, const Bytef* source,
     Log(LogLevel::LOG_INFO, "uncompress2 Line ", __LINE__,
         ", accelerator return code ", ret, ", sourceLen ", *sourceLen,
         ", destLen ", *destLen, "\n");
-  } else if (configs[USE_ZLIB_UNCOMPRESS] && orig_uncompress2 != nullptr) {
-    // refer to comment in compress2
-    in_call = true;
-    ret = orig_uncompress2(dest, destLen, source, sourceLen);
-    in_call = false;
-    Log(LogLevel::LOG_INFO, "uncompress2 Line ", __LINE__,
-        ", zlib return code ", ret, ", sourceLen ", *sourceLen, ", destLen ",
-        *destLen, "\n");
+  } else if (configs[USE_ZLIB_UNCOMPRESS]) {
+    // refer to comment in deflate
+    if (orig_uncompress2 == nullptr) {
+      ret = Z_VERSION_ERROR;
+    } else {
+      // refer to comment in compress2
+      in_call = true;
+      ret = orig_uncompress2(dest, destLen, source, sourceLen);
+      in_call = false;
+      Log(LogLevel::LOG_INFO, "uncompress2 Line ", __LINE__,
+          ", zlib return code ", ret, ", sourceLen ", *sourceLen, ", destLen ",
+          *destLen, "\n");
+    }
   } else {
     ret = Z_DATA_ERROR;
   }
@@ -1167,9 +1189,6 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
 
   if (ret == 0) {
     gz->data_buf_pos = input_len;
-  } else if (orig_deflate == nullptr) {
-    // No accelerator result and no zlib to fall back to.
-    return 1;
   } else {
     gz->deflate_stream.next_in = (Bytef*)(gz->data_buf);
     gz->deflate_stream.avail_in =
@@ -1185,9 +1204,7 @@ static int CompressAndWrite(gzFile file, GzipFile* gz) {
     if (ret == Z_STREAM_END) {
       gz->data_buf_pos = gz->data_buf_content - gz->deflate_stream.avail_in;
       output_len = gz->io_buf_size - gz->deflate_stream.avail_out;
-      if (orig_deflateReset != nullptr) {
-        orig_deflateReset(&gz->deflate_stream);
-      }
+      orig_deflateReset(&gz->deflate_stream);
     } else {
       return 1;
     }
@@ -1215,6 +1232,18 @@ int ZEXPORT gzwrite(gzFile file, voidpc buf, unsigned len) {
   if (gz == nullptr) {
     return orig_gzwrite != nullptr ? orig_gzwrite(file, buf, len) : 0;
   }
+
+  // Same reasoning as gzread: validate the whole set up front rather than
+  // partway through CompressAndWrite, which by then may have buffered data
+  // that has to be either written or dropped. 0 is what zlib returns for a
+  // write it could not perform.
+  if (orig_gzwrite == nullptr || orig_deflate == nullptr ||
+      orig_deflateReset == nullptr || orig_deflateInit2_ == nullptr) {
+    Log(LogLevel::LOG_ERROR, "gzwrite Line ", __LINE__,
+        " a required zlib symbol is unresolved, cannot write\n");
+    return 0;
+  }
+
   Log(LogLevel::LOG_INFO, "gzwrite Line ", __LINE__, ", file ",
       static_cast<void*>(file), ", buf ", buf, ", len ", len, "\n");
 
@@ -1274,6 +1303,21 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
   auto gz = gzip_files.Get(file);
   if (gz == nullptr) {
     return orig_gzread != nullptr ? orig_gzread(file, buf, len) : -1;
+  }
+
+  // Check every symbol this function may need before touching any state. The
+  // accelerator path can hand the rest of the file to zlib at any point, and a
+  // concatenated stream needs a reset between members, so a check made partway
+  // through would have to either abandon bytes already copied into the
+  // caller's buffer or continue without making progress. Fail fast instead.
+  // orig_inflateInit2_ matters because GzipFile::Reset only initializes
+  // inflate_stream when it resolved; without it the fallback would inflate on
+  // a zeroed stream.
+  if (orig_gzread == nullptr || orig_inflate == nullptr ||
+      orig_inflateReset == nullptr || orig_inflateInit2_ == nullptr) {
+    Log(LogLevel::LOG_ERROR, "gzread Line ", __LINE__,
+        " a required zlib symbol is unresolved, cannot read\n");
+    return -1;
   }
 
   Log(LogLevel::LOG_INFO, "gzread Line ", __LINE__, ", file ",
@@ -1365,11 +1409,6 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
             }
           }
 
-          if (gz->use_zlib_for_decompression && orig_inflate == nullptr) {
-            read_bytes = -1;
-            goto gzread_end;
-          }
-
           if (gz->use_zlib_for_decompression) {
             gz->inflate_stream.next_in = (Bytef*)(gz->io_buf);
             gz->inflate_stream.avail_in =
@@ -1388,7 +1427,7 @@ int ZEXPORT gzread(gzFile file, voidp buf, unsigned len) {
                   (gz->io_buf_content - gz->inflate_stream.avail_in);
               gz->data_buf_content +=
                   (gz->data_buf_size - gz->inflate_stream.avail_out);
-              if (ret == Z_STREAM_END && orig_inflateReset != nullptr) {
+              if (ret == Z_STREAM_END) {
                 orig_inflateReset(&gz->inflate_stream);
               }
             } else if (ret != Z_OK) {
@@ -1445,10 +1484,19 @@ int ZEXPORT gzclose(gzFile file) {
   int ret = 0;
   if (gz->path != ZLIB &&
       (gz->mode == FileMode::WRITE || gz->mode == FileMode::APPEND)) {
-    // Compress any remaining buffered data
+    // Compress any remaining buffered data. CompressAndWrite may fall back to
+    // zlib, so it needs the same symbols gzwrite checks for; without them the
+    // buffered data cannot be flushed and the file would be silently
+    // truncated, so report the failure.
     int write_ret = 0;
     if (gz->data_buf_content > 0) {
-      write_ret = CompressAndWrite(file, gz.get());
+      if (orig_deflate == nullptr || orig_deflateReset == nullptr) {
+        Log(LogLevel::LOG_ERROR, "gzclose Line ", __LINE__,
+            " a required zlib symbol is unresolved, cannot flush\n");
+        write_ret = 1;
+      } else {
+        write_ret = CompressAndWrite(file, gz.get());
+      }
     }
 
     // Capture file size and name before gzclose


### PR DESCRIPTION
Harden the interposition layer against partial initialization and missing per-stream state.

**Partial initialization.** `LOAD_SYMBOL` no longer returns early on failure — that left every
*later* `orig_*` pointer null, so one missing symbol took out unrelated entry points. It now logs,
counts, and keeps resolving.

There is deliberately no global "shim disabled" flag. An earlier revision used one, but the
fallback path itself dereferences the pointer that may be null, so `if (... || shim_disabled)
return orig_deflate(...)` would call through null precisely when the flag was set. Each wrapper
checks the pointer it is about to use instead, and where the shim cannot serve a call it returns
what zlib returns for an unusable library: `Z_VERSION_ERROR`, or the per-API equivalent
(`gzopen` → `nullptr`, `gzread` → `-1`, `gzwrite` → `0`, `gzclose` → `Z_STREAM_ERROR`). A missing
symbol is never reported as `Z_DATA_ERROR`, which would make an unusable library look like
corrupt input.

`gzread`, `gzwrite` and `gzclose` validate their whole symbol set **on entry**. Each drives a
multi-step sequence that can hand work to zlib at any point, so a mid-sequence check must either
abandon bytes already given to the caller or continue without progress — `gzread` hit the latter
and spun forever on a concatenated stream when `orig_inflateReset` was missing.

**Null per-stream state.** Added null checks on `ShardedMap::Get()` results in `deflate`,
`inflate`, `deflateSetDictionary`, `inflateSetDictionary`, `gzwrite`, `gzread`, `gzclose`, `gzeof`,
`GetDeflateExecutionPath` and `GetInflateExecutionPath`. `Get()` returns null for any stream the
shim never registered — a failed `*Init`, an unintercepted entry point such as
`gzopen64`/`deflateCopy`, or one already `Unset()` by a previous `*End`. Each previously
dereferenced a null `shared_ptr`.

**Testing.** 7 new `UnregisteredStreamTest` cases. Missing-symbol paths are not unit-testable —
`orig_*` are `static`, resolved before any test runs, and the test binary links real `libz` — so
they were verified by forcing a symbol null at init: single-member and two-member gzip files both
fail cleanly, where previously the two-member case hung. With all symbols present, output is
byte-identical to before.

Full suite with QAT + IAA + IGZIP on hardware: 28701 tests, 24381 pass, 4320 pre-existing skips,
0 fail. Clean with all backends off and across `DEBUG_LOG` × `ENABLE_STATISTICS`;
`clang-format` clean.
