### PR TITLE
Fix init/state registration correctness

### DIFF
--- a/tests/zlib_accel_test.cpp
+++ b/tests/zlib_accel_test.cpp
@@ -1331,10 +1331,9 @@ TEST_F(UnregisteredStreamTest, DeflateAfterFailedInitDoesNotCrash) {
   z_stream strm;
   memset(&strm, 0, sizeof(strm));
 
-  // window_bits is invalid, so zlib rejects the stream. The shim registers
-  // settings before delegating, so an entry does exist here — what matters is
-  // that deflate() on a stream zlib never initialized still reports zlib's
-  // error instead of trusting that state.
+  // window_bits is invalid, so zlib rejects the stream and the shim registers
+  // nothing for it. deflate() therefore finds no entry and has to hand the call
+  // to zlib, which reports its own error, rather than dereferencing the miss.
   ASSERT_EQ(deflateInit2(&strm, 6, Z_DEFLATED, 99, 8, Z_DEFAULT_STRATEGY),
             Z_STREAM_ERROR);
 
@@ -1458,6 +1457,131 @@ TEST_F(UnregisteredStreamTest, GzFunctionsOnUnregisteredFile) {
   EXPECT_EQ(gzread(nullptr, buf.data(), static_cast<unsigned>(buf.size())), -1);
   EXPECT_EQ(gzwrite(nullptr, buf.data(), static_cast<unsigned>(buf.size())), 0);
   EXPECT_EQ(gzclose(nullptr), Z_STREAM_ERROR);
+}
+
+// These tests mutate the global path configuration, so restore it in TearDown
+// rather than at the end of the test body: ASSERT_* returns from the function,
+// which would skip an inline restore and leak the setting into later tests.
+class GzipFileTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    saved_iaa_compress_ = GetConfig(USE_IAA_COMPRESS);
+    saved_qat_compress_ = GetConfig(USE_QAT_COMPRESS);
+    saved_zlib_compress_ = GetConfig(USE_ZLIB_COMPRESS);
+    saved_iaa_uncompress_ = GetConfig(USE_IAA_UNCOMPRESS);
+    saved_qat_uncompress_ = GetConfig(USE_QAT_UNCOMPRESS);
+    saved_zlib_uncompress_ = GetConfig(USE_ZLIB_UNCOMPRESS);
+  }
+
+  void TearDown() override {
+    SetConfig(USE_IAA_COMPRESS, saved_iaa_compress_);
+    SetConfig(USE_QAT_COMPRESS, saved_qat_compress_);
+    SetConfig(USE_ZLIB_COMPRESS, saved_zlib_compress_);
+    SetConfig(USE_IAA_UNCOMPRESS, saved_iaa_uncompress_);
+    SetConfig(USE_QAT_UNCOMPRESS, saved_qat_uncompress_);
+    SetConfig(USE_ZLIB_UNCOMPRESS, saved_zlib_uncompress_);
+    remove("file.gz");
+  }
+
+ private:
+  uint32_t saved_iaa_compress_ = 0;
+  uint32_t saved_qat_compress_ = 0;
+  uint32_t saved_zlib_compress_ = 0;
+  uint32_t saved_iaa_uncompress_ = 0;
+  uint32_t saved_qat_uncompress_ = 0;
+  uint32_t saved_zlib_uncompress_ = 0;
+};
+
+// gzeof has to answer for files the shim handed to zlib as well as the ones it
+// decompressed itself. gz->reached_eof is only ever set by the accelerator read
+// loop, so on the zlib path it stays false forever and gzeof must defer to
+// orig_gzeof. Assert on the return value rather than looping until gzeof is
+// true: without the fix the loop form hangs instead of failing.
+TEST_F(GzipFileTest, GzeofReportsEofOnZlibPath) {
+  // No accelerator enabled means gzwrite/gzread both delegate to zlib, so the
+  // file ends up on the ZLIB path.
+  SetCompressPath(ZLIB, false, false, false);
+  SetUncompressPath(ZLIB, false, false);
+
+  std::vector<char> input(8192, 'a');
+  ASSERT_EQ(ZlibCompressGzipFile(input.data(), input.size()), Z_OK);
+
+  const char* filename = "file.gz";
+  gzFile fp = gzopen(filename, "rb");
+  ASSERT_NE(fp, nullptr);
+
+  // Room to spare, so the loop ends on a zero-length read rather than on a full
+  // buffer — zlib only sets its end-of-file indicator once a read runs off the
+  // end of the compressed data.
+  std::vector<char> output(input.size() + 512, 0);
+  size_t read_total = 0;
+  int read_ret = 0;
+  do {
+    read_ret = gzread(fp, output.data() + read_total,
+                      static_cast<unsigned>(output.size() - read_total));
+    ASSERT_GE(read_ret, 0);
+    read_total += static_cast<size_t>(read_ret);
+    ASSERT_LE(read_total, output.size());
+  } while (read_ret > 0);
+
+  ASSERT_EQ(read_total, input.size());
+  output.resize(read_total);
+  EXPECT_EQ(output, input);
+
+  // zlib has consumed the whole member, so gzeof must say so.
+  EXPECT_NE(gzeof(fp), 0);
+
+  EXPECT_EQ(gzclose(fp), Z_OK);
+}
+
+// On the accelerator path reached_eof only records that a read of the file came
+// up short, which happens while data_buf/io_buf still hold bytes gzread has not
+// returned yet. gzeof reporting EOF there truncates the common
+// "while (!gzeof(file)) gzread(...)" loop, so it has to account for the
+// buffered data too.
+TEST_F(GzipFileTest, GzeofDoesNotReportEofWithBufferedData) {
+  // Write with zlib so the file is a plain gzip member, and read back with an
+  // accelerator enabled so gzread takes its own buffered path. Which
+  // accelerator does not matter; if neither is available the read falls back to
+  // zlib and the loop below still has to deliver every byte.
+  SetCompressPath(ZLIB, false, false, false);
+#if defined(USE_IAA)
+  SetUncompressPath(IAA, true, false);
+#elif defined(USE_QAT)
+  SetUncompressPath(QAT, true, false);
+#else
+  SetUncompressPath(ZLIB, false, false);
+#endif
+
+  std::vector<char> input(8192, 'a');
+  ASSERT_EQ(ZlibCompressGzipFile(input.data(), input.size()), Z_OK);
+
+  const char* filename = "file.gz";
+  gzFile fp = gzopen(filename, "rb");
+  ASSERT_NE(fp, nullptr);
+
+  // Read in chunks smaller than the file so a chunk boundary lands after the
+  // file has been fully read but before all of it has been handed back. This is
+  // the loop shape the bug breaks: gzeof gates the next read.
+  std::vector<char> output;
+  std::vector<char> chunk(4096, 0);
+  int iterations = 0;
+  while (gzeof(fp) == 0) {
+    int read_ret =
+        gzread(fp, chunk.data(), static_cast<unsigned>(chunk.size()));
+    ASSERT_GE(read_ret, 0);
+    output.insert(output.end(), chunk.begin(), chunk.begin() + read_ret);
+    // The loop must terminate through gzeof, not run away.
+    ASSERT_LT(++iterations, 64);
+    if (read_ret == 0) {
+      break;
+    }
+  }
+
+  EXPECT_EQ(output.size(), input.size());
+  EXPECT_EQ(output, input);
+
+  EXPECT_EQ(gzclose(fp), Z_OK);
 }
 
 class ShardedMapTest : public ::testing::Test {};

--- a/zlib_accel.cpp
+++ b/zlib_accel.cpp
@@ -274,9 +274,16 @@ int ZEXPORT deflateInit_(z_streamp strm, int level, const char* version,
     return Z_VERSION_ERROR;
   }
 
-  deflate_stream_settings.Set(strm, level, Z_DEFLATED, 15, 8,
-                              Z_DEFAULT_STRATEGY);
-  return orig_deflateInit_(strm, level, version, stream_size);
+  // Register only once zlib has accepted the stream. On failure the app never
+  // calls deflateEnd, so an entry made here would outlive the z_streamp; and
+  // zlib leaves an already-initialized stream untouched when it rejects new
+  // parameters, so the previous settings must stay in place.
+  int ret = orig_deflateInit_(strm, level, version, stream_size);
+  if (ret == Z_OK) {
+    deflate_stream_settings.Set(strm, level, Z_DEFLATED, 15, 8,
+                                Z_DEFAULT_STRATEGY);
+  }
+  return ret;
 }
 
 int ZEXPORT deflateInit2_(z_streamp strm, int level, int method,
@@ -290,10 +297,13 @@ int ZEXPORT deflateInit2_(z_streamp strm, int level, int method,
     return Z_VERSION_ERROR;
   }
 
-  deflate_stream_settings.Set(strm, level, method, window_bits, mem_level,
-                              strategy);
-  return orig_deflateInit2_(strm, level, method, window_bits, mem_level,
-                            strategy, version, stream_size);
+  int ret = orig_deflateInit2_(strm, level, method, window_bits, mem_level,
+                               strategy, version, stream_size);
+  if (ret == Z_OK) {
+    deflate_stream_settings.Set(strm, level, method, window_bits, mem_level,
+                                strategy);
+  }
+  return ret;
 }
 
 int ZEXPORT deflateSetDictionary(z_streamp strm, const Bytef* dictionary,
@@ -465,8 +475,11 @@ int ZEXPORT inflateInit_(z_streamp strm, const char* version, int stream_size) {
     return Z_VERSION_ERROR;
   }
 
-  inflate_stream_settings.Set(strm, 15);
-  return orig_inflateInit_(strm, version, stream_size);
+  int ret = orig_inflateInit_(strm, version, stream_size);
+  if (ret == Z_OK) {
+    inflate_stream_settings.Set(strm, 15);
+  }
+  return ret;
 }
 
 int ZEXPORT inflateInit2_(z_streamp strm, int window_bits, const char* version,
@@ -478,8 +491,11 @@ int ZEXPORT inflateInit2_(z_streamp strm, int window_bits, const char* version,
     return Z_VERSION_ERROR;
   }
 
-  inflate_stream_settings.Set(strm, window_bits);
-  return orig_inflateInit2_(strm, window_bits, version, stream_size);
+  int ret = orig_inflateInit2_(strm, window_bits, version, stream_size);
+  if (ret == Z_OK) {
+    inflate_stream_settings.Set(strm, window_bits);
+  }
+  return ret;
 }
 
 int ZEXPORT inflateSetDictionary(z_streamp strm, const Bytef* dictionary,
@@ -1540,10 +1556,20 @@ int ZEXPORT gzclose(gzFile file) {
 
 int ZEXPORT gzeof(gzFile file) {
   auto gz = gzip_files.Get(file);
-  if (gz == nullptr) {
+  // reached_eof is only maintained by the accelerator read path in gzread. Once
+  // a file is on the zlib path, zlib owns its end-of-file state, so ask zlib
+  // rather than reporting a flag that will never be set.
+  if (gz == nullptr || gz->path == ZLIB) {
     return orig_gzeof != nullptr ? orig_gzeof(file) : 0;
   }
-  return gz->reached_eof;
+  // reached_eof only records that a read of the file came up short; the buffers
+  // may still hold data gzread has not handed back yet. Reporting EOF here
+  // would silently truncate a "while (!gzeof(file)) gzread(...)" loop, so match
+  // gzread's own view of whether more data is available (see the
+  // file_data_remaining/data_remaining checks in its loop above).
+  bool data_remaining = (gz->data_buf_content - gz->data_buf_pos) > 0 ||
+                        (gz->io_buf_content - gz->io_buf_pos) > 0;
+  return gz->reached_eof && !data_remaining;
 }
 #if defined(__clang__)
 #pragma clang attribute pop


### PR DESCRIPTION
- `deflateInit_`, `deflateInit2_`, `inflateInit_`, `inflateInit2_`: call the original zlib init function first and only register stream settings on `Z_OK`. Previously settings were registered unconditionally, so a failed init left a stale entry keyed by a `z_streamp` the app may free (it never calls the matching `End`), and a *rejected re-init* overwrote the settings of a stream zlib had left valid and usable.

- `gzeof`: two fixes, same root cause — `reached_eof` was trusted where the shim does not fully maintain it.
  - Fall through to `orig_gzeof()` when the file has no map entry or is on the `ZLIB` path. `reached_eof` is only maintained by the accelerator read path, so on the zlib path it stayed false forever and `gzeof` never reported EOF, causing infinite read loops.
  - On the accelerator path, do not report EOF while `data_buf`/`io_buf` still hold bytes `gzread` has not returned. `reached_eof` only records that a `read()` of the file came up short, so `while (!gzeof(fp)) gzread(...)` exited early and **silently truncated** with a success return. Measured: 4096 of 8192 bytes on an 8KB file read in 4KB chunks. `gzeof` now checks the same buffer state `gzread` already does.

Tests: two `GzipFileTest` cases, one per `gzeof` fix, each verified to fail with its hunk reverted. Full suite with QAT+IAA+IGZIP on real hardware: 28703 tests, 24383 passed, 4320 skipped, 0 failed.

Rebased onto `main` after #65; depends on its null guards, since conditional registration means a failed `*Init` leaves no map entry.